### PR TITLE
Make command a string

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -42,7 +42,7 @@ type BuildConfig struct {
 	// URI identifying the Docker image to use for building the binary.
 	BuilderImage string `toml:"builder_image"`
 	// List of commands to pass to the docker run command.
-	Command []string `toml:"command"`
+	Command string `toml:"command"`
 	// The path, relative to the root of the git repository, where the binary
 	// built by the `docker run` command is expected to be found.
 	OutputPath string `toml:"output_path"`
@@ -129,7 +129,7 @@ func (b *BuildConfig) Build() error {
 	args = append(args, "run")
 	args = append(args, defaultDockerRunFlags...)
 	args = append(args, b.BuilderImage)
-	args = append(args, b.Command...)
+	args = append(args, b.Command)
 	cmd := exec.Command("docker", args...)
 
 	stderr, err := cmd.StderrPipe()

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -69,7 +69,7 @@ func checkBuildConfig(got *BuildConfig, t *testing.T) {
 		Repo:                     "https://github.com/project-oak/oak",
 		CommitHash:               "0f2189703c57845e09d8ab89164a4041c0af0a62",
 		BuilderImage:             "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320",
-		Command:                  []string{"./scripts/runner", "build-functions-server"},
+		Command:                  "./scripts/runner build-functions-server",
 		OutputPath:               "./oak_functions/loader/bin/oak_functions_loader",
 		ExpectedBinarySha256Hash: "15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c",
 	}

--- a/slsa/slsa.go
+++ b/slsa/slsa.go
@@ -63,7 +63,7 @@ type Parameters struct {
 	Repository     string
 	CommitHash     string `json:"commit_hash"`
 	BuilderImage   string `json:"builder_image"`
-	Command        []string
+	Command        string
 }
 
 // ParseProvenanceFile parses a JSON file in the given path into a Provenance object.

--- a/testdata/build.toml
+++ b/testdata/build.toml
@@ -1,6 +1,6 @@
 repo = "https://github.com/project-oak/oak"
 commit_hash = "0f2189703c57845e09d8ab89164a4041c0af0a62"
 builder_image = "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320"
-command = ["./scripts/runner", "build-functions-server"]
+command = "./scripts/runner build-functions-server"
 output_path = "./oak_functions/loader/bin/oak_functions_loader"
 expected_binary_sha256_hash = "15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c"


### PR DESCRIPTION
It is parsed as a string, hence we'd like to change it. The SLSA amber build type uses a string as well.

This is the first in a series of small PRs to implement #8.