### PR TITLE
Endorsement v0.1 schemas and example

### DIFF
--- a/schema/amber-endorsement/v0.1/example.json
+++ b/schema/amber-endorsement/v0.1/example.json
@@ -1,0 +1,18 @@
+{
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "subject": [
+      {
+        "name": "oak_functions_loader-0f2189703c57845e09d8ab89164a4041c0af0a62",
+        "digest": {
+          "sha256": "15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c"
+        }
+      }
+    ],
+    "predicateType": "https://github.com/project-oak/transparent-release/schema/amber-endorsement/v0.1/predicate.json",
+    "predicate": {
+      "validityPeriod": {
+        "releaseTime": "2022-02-01T10:20:50.32Z",
+        "expiryTime": "2022-03-01T10:20:50.32Z"
+      }
+    }
+  }

--- a/schema/amber-endorsement/v0.1/predicate.json
+++ b/schema/amber-endorsement/v0.1/predicate.json
@@ -1,0 +1,28 @@
+{
+    "definitions": {},
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Amber Endorsement v0.1",
+    "type": "object",
+    "required": [
+      "validityPeriod"
+    ],
+    "properties": {
+      "validityPeriod": {
+        "type": "object",
+        "required": [
+          "releaseTime"
+        ],
+        "properties": {
+          "releaseTime": {
+            "type": "string",
+            "description": "Timestamp in RFC 3339 format"
+          },
+          "expiryTime": {
+            "type": "string",
+            "description": "Timestamp in RFC 3339 format"
+          }
+        }
+      }
+    }
+  }
+  

--- a/schema/amber-endorsement/v0.1/statement.json
+++ b/schema/amber-endorsement/v0.1/statement.json
@@ -1,0 +1,81 @@
+{
+	"definitions": {},
+	"$schema": "http://json-schema.org/draft-07/schema#", 
+	"type": "object",
+	"required": [
+		"_type",
+		"subject",
+		"predicateType",
+		"predicate"
+	],
+	"properties": {
+		"_type": {
+			"const": "https://in-toto.io/Statement/v0.1"
+		},
+		"subject": {
+			"type": "array",
+			"default": [],
+			"items":{
+				"type": "object",
+				"required": [
+					"name",
+					"digest"
+				],
+				"properties": {
+					"name": {
+						"type": "string",
+						"examples": [
+							"oak_functions_loader-0f2189703c57845e09d8ab89164a4041c0af0a62"
+						]
+					},
+					"digest": {
+						"type": "object",
+						"required": [
+							"sha256"
+						],
+						"properties": {
+							"sha256": {
+								"type": "string",
+								"examples": [
+									"15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c"
+								]
+							}
+						}
+					}
+
+				}
+			}
+
+		},
+		"predicateType": {
+			"const": "https://github.com/project-oak/transparent-release/schema/amber-endorsement/v0.1/predicate.json"
+		},
+		"predicate": {
+			"type": "object",
+			"required": [
+				"validityPeriod"
+			],
+			"properties": {
+				"validityPeriod": {
+					"type": "object",
+					"required": [
+						"releaseTime",
+						"expiryTime"
+					],
+					"properties": {
+						"releaseTime": {
+							"type": "string",
+                            "description": "Timestamp in RFC 3339 format, e.g., 2022-02-01T10:20:50.32Z"
+						},
+						"expiryTime": {
+							"type": "string",
+                            "description": "Timestamp in RFC 3339 format, e.g., 2022-02-01T10:20:50.32Z"
+						}
+					}
+				}
+
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
Schema and an example for Endorsement v0.1 predicate. An endorsement file is an in-toto statement that specifies a validity time-range that is required for implementing passive revocation when releasing, signing, and publishing binaries in a transparency log. 