### PR TITLE
Add CLI interface for verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ bazel run  //cmd/verify:main -- \
 ```
 
 This fetches the sources from the Git repository specified in the
-SLSA statement file, re-runns the build, and verifies that it yields the
+SLSA statement file, re-runs the build, and verifies that it yields the
 expected hash. It is also possible to perform the release from an already
 existing local repository, by specifying `-git_root_dir`. In this case, the
 binary will be built from the repo, only if the latest commit matches the one

--- a/README.md
+++ b/README.md
@@ -51,12 +51,26 @@ $ bazel run  //cmd/build:main -- \
 
 ## Verifying provenances
 
-**TODO: Do we need a command line tool for `verify`, for instance to be used by
-external verifiers?**
+A SLSA provenance of the Amber build type can be verified with the following
+command:
 
-We don't expect developers to run the verification logic manually, but to use it
-in their release processes to verify the binaries before release.
-**TODO: Add details based on our release process.**
+```bash
+$ bazel run  //cmd/build:main -- \
+  -config <path-to-transparent-release>/testdata/build.toml \
+```
+
+This fetches the sources from the Git repository specified in the
+SLSA statement file, re-runns the build, and verifies that it yields the
+expected hash. It is also possible to perform the release from an already
+existing local repository, by specifying `-git_root_dir`. In this case, the
+binary will be built from the repo, only if the latest commit matches the one
+specified in the config file.
+
+```bash
+$ bazel run  //cmd/build:main -- \
+  -config <path-to-transparent-release>/testdata/build.toml \
+  -git_root_dir <path-to-git-repo-root>
+```
 
 ## SLSA Provenance Predicate
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ A SLSA provenance of the Amber build type can be verified with the following
 command:
 
 ```bash
-$ bazel run  //cmd/build:main -- \
-  -config <path-to-transparent-release>/testdata/build.toml \
+$ bazel run  //cmd/verify:main -- \
+  -config <path-to-transparent-release>/schema/amber-slsa-buildtype/v1-example-statement.json
 ```
 
 This fetches the sources from the Git repository specified in the
@@ -67,8 +67,8 @@ binary will be built from the repo, only if the latest commit matches the one
 specified in the config file.
 
 ```bash
-$ bazel run  //cmd/build:main -- \
-  -config <path-to-transparent-release>/testdata/build.toml \
+$ bazel run  //cmd/verify:main -- \
+  -config <path-to-transparent-release>/schema/amber-slsa-buildtype/v1-example-statement.json \
   -git_root_dir <path-to-git-repo-root>
 ```
 

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package main contains a command-line tool for building binaries.
+// Package main contains a command-line tool for verifying Amber provenance files.
 package main
 
 import (

--- a/cmd/verify/BUILD
+++ b/cmd/verify/BUILD
@@ -18,7 +18,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-
 go_binary(
     name = "main",
     srcs = ["main.go"],

--- a/cmd/verify/BUILD
+++ b/cmd/verify/BUILD
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+
+go_binary(
+    name = "main",
+    srcs = ["main.go"],
+    deps = ["//verify:verify"],
+)

--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -29,7 +29,7 @@ func main() {
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
 	flag.Parse()
 
-	if err := verify.Verify(*buildConfigPathPtr, gitRootDirPtr); err != nil {
+	if err := verify.Verify(*buildConfigPathPtr, *gitRootDirPtr); err != nil {
 		log.Fatalf("error when verifyfing the provenance: %v", err)
 	}
 }

--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main contains a command-line tool for building binaries.
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/project-oak/transparent-release/verify"
+)
+
+func main() {
+	buildConfigPathPtr := flag.String("config", "",
+		"Required - Path to SLSA provenance file of the Amber build type.")
+	gitRootDirPtr := flag.String("git_root_dir", "",
+		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
+	flag.Parse()
+
+	if err := verify.Verify(*buildConfigPathPtr, gitRootDirPtr); err != nil {
+		log.Fatalf("error when verifyfing the provenance: %v", err)
+	}
+}


### PR DESCRIPTION
Implements #19. The code's basically the same as in `cmd/build`, as outlined in https://github.com/project-oak/transparent-release/issues/19#issuecomment-1032784186. :) 