### PR TITLE
Add BUILD.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,23 @@
+#
+# Copyright 2022 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(
+    default_visibility = ["//:__subpackages__"],
+    licenses = ["notice"],
+)
+
+# Export LICENSE file for projects that reference transparent-release in Bazel as an external dependency.
+exports_files(["LICENSE"])


### PR DESCRIPTION
There is a conflict between the package `build` and the `BUILD` file. This results in the `BUILD` file being automatically deleted when checking out the repository on Mac OS. 

This PR adds `BUILD.bazel` which is a copy of `BUILD` to solve this conflict, as a temporary solution. We should perhaps instead rename the `build` package. 