### PR TITLE
Souffle Binary with Static C++ Runtime Libs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ jobs:
           mkdir -p "${GITHUB_WORKSPACE}/bin/"
           mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-      - name: Install mcpp #mcpp is a dependency of Souffle
-        run: sudo apt-get install -y mcpp 
+      - name: Install souffle deps #install dependencies of Souffle
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mcpp libstdc++6 libc6-dev libc6
       - name: Test
         run: |
           "${GITHUB_WORKSPACE}/bin/bazel" test --test_output=streamed //...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,8 @@ jobs:
           mkdir -p "${GITHUB_WORKSPACE}/bin/"
           mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
-      - name: Install souffle deps #install dependencies of Souffle
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y mcpp libstdc++6 libc6-dev libc6
+      - name: Install mcpp #mcpp is a dependency of Souffle
+        run: sudo apt-get install -y mcpp 
       - name: Test
         run: |
           "${GITHUB_WORKSPACE}/bin/bazel" test --test_output=streamed //...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
       - name: Install mcpp #mcpp is a dependency of Souffle
-        run: sudo apt-get install -y mcpp clang
+        run: sudo apt-get install -y mcpp 
       - name: Test
         run: |
           "${GITHUB_WORKSPACE}/bin/bazel" test --test_output=streamed //...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           mv bazelisk-linux-amd64 "${GITHUB_WORKSPACE}/bin/bazel"
           chmod +x "${GITHUB_WORKSPACE}/bin/bazel"
       - name: Install mcpp #mcpp is a dependency of Souffle
-        run: sudo apt-get install -y mcpp 
+        run: sudo apt-get install -y mcpp clang
       - name: Test
         run: |
           "${GITHUB_WORKSPACE}/bin/bazel" test --test_output=streamed //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,5 +106,5 @@ http_file(
   executable = True,
   downloaded_file_path = "souffle-bin",
   urls = ["https://github.com/google-research/raksha/releases/download/v0.1-Linux/souffle-bin"],
-  sha256 = "8e36156acdd5b1cf3225a865d75c8a4ff201ffa922ae1533201fd40aca0e9c2f",
+  sha256 = "48f39b9abd0065801a199e58ef1edcc32ab38dd88ba714194d6bd621f203a7fa",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,5 +106,5 @@ http_file(
   executable = True,
   downloaded_file_path = "souffle-bin",
   urls = ["https://github.com/google-research/raksha/releases/download/v0.1-Linux/souffle-bin"],
-  sha256 = "4bb5c1d5c18107cec4d40409ce3831304d6b9aad2e9e4f46270105a9152dc7c3"
+  sha256 = "8e36156acdd5b1cf3225a865d75c8a4ff201ffa922ae1533201fd40aca0e9c2f",
 )


### PR DESCRIPTION
This PR fixes the CI regression by using a souffle binary that statically links the C/C++ runtime libraries. See also https://github.com/google-research/raksha/pull/484