### PR TITLE
Interface for defining wrappers

### DIFF
--- a/experimental/auth-logic/BUILD
+++ b/experimental/auth-logic/BUILD
@@ -40,6 +40,22 @@ go_test(
     ],
 )
 
+go_library(
+  name = "wrapper_interface",
+  importpath = "github.com/project-oak/transparent-release/experimental/auth-logic",
+  srcs = [
+    "wrapper_interface.go",
+  ],
+)
+
+
+go_test(
+  name = "wrapper_interface_test",
+  size = "small",
+  srcs = ["wrapper_interface_test.go"],
+  embed = [":wrapper_interface"],
+)
+
 # This rule runs the authorizaiton logic compiler on "simple.auth_logic"
 # as an input and produces the resulting souffle code and CSVs containing the 
 # results of queries. These outputs are used by "simple_auth_logic_test"

--- a/experimental/auth-logic/wrapper_interface.go
+++ b/experimental/auth-logic/wrapper_interface.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package authlogic
+
+import (
+	"fmt"
+	"os"
+)
+
+// This struct represents an authorization logic statement (or sequence of
+// statements) without a principal. These statements might include rules or
+// predicates. For example, the following is an unattributed statement:
+// ```
+// foo("bar").
+// "SomePrincipal" canActAs baz("bar") :- foo("bar").
+// ```
+// NOTE: Because wrappers will generally emit UnattributedStatements,
+// it might be useful to also give a field for the relation declarations
+// for the relations referenced in the statement. Without this, the
+// interface will work by having the code that consumes the wrappers emit
+// all the necessary declarations for the wrappers it uses.
+type UnattributedStatement struct {
+	Contents string
+}
+
+func (statement UnattributedStatement) String() string {
+	return statement.Contents
+}
+
+type Principal struct {
+	Contents string
+}
+
+func (principal Principal) String() string {
+	return principal.Contents
+}
+
+type AuthLogic struct {
+	Speaker   Principal
+	Statement UnattributedStatement
+}
+
+func (authLogic AuthLogic) String() string {
+	return fmt.Sprintf("%v says { %v }", authLogic.Speaker, authLogic.Statement)
+}
+
+// This interface defines a way of emitting authorization logic statements
+// that are not attributed to any principal. A wrapper might implement this
+// method by parsing a file in a particular format or checking the system clock
+// before emitting an authorization logic statement.
+type Wrapper interface {
+	Wrap() UnattributedStatement
+}
+
+// This interface defines a way of granting principal names to wrappers. This
+// is defined separately from `Wrapper` to allow one piece of software to
+// define how to emit authorization logic from a source (by defining `Wrapper`)
+// while allowing the consumer of the wrapper to independently decide how
+// to attach an identity to it (by defining `IdentifiableWrapper`)
+// For example, one definition could be to give a constant pre-defined name.
+// Another definition could be to take the hash of the Wrap function.
+// Yet another way could be to compute a hash covering both the Wrap
+// function and the value of the object implementing this interface.
+type IdentifiableWrapper interface {
+	Wrapper
+	Identify() Principal
+}
+
+func wrapAttributed(wrapper IdentifiableWrapper) AuthLogic {
+	return AuthLogic{wrapper.Identify(), wrapper.Wrap()}
+}
+
+func emitAuthLogicToFile(authLogic AuthLogic, filepath string) error {
+	f, createErr := os.Create(filepath)
+	if createErr != nil {
+		return createErr
+	}
+	defer f.Close()
+	_, writeErr := f.WriteString(authLogic.String())
+	return writeErr
+}
+
+func EmitWrapperStatement(wrapper IdentifiableWrapper, filepath string) error {
+	return emitAuthLogicToFile(wrapAttributed(wrapper), filepath)
+}

--- a/experimental/auth-logic/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrapper_interface_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authlogic contains logic and tests for interfacing with the
+// authorization logic compiler
+package authlogic
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+)
+
+type IntPair struct {
+	x int
+	y int
+}
+
+// Wrapper for pair of ints
+func (p IntPair) Wrap() UnattributedStatement {
+	return UnattributedStatement{fmt.Sprintf("sum(%v, %v, %v)", p.x, p.y, p.x+p.y)}
+}
+
+func (p IntPair) Identify() Principal {
+	return Principal{"Summer"}
+}
+
+func TestSimpleWrapper(t *testing.T) {
+	handleErr := func(err error) {
+		if err != nil {
+			t.Fatalf("test generated error %v", err)
+			panic(err)
+		}
+	}
+
+	writeErr := EmitWrapperStatement(IntPair{2, 3}, "wrapped_sum.auth_logic")
+	handleErr(writeErr)
+
+	expectedString := "Summer says { sum(2, 3, 5) }"
+	resultBytes, readErr := ioutil.ReadFile("wrapped_sum.auth_logic")
+	handleErr(readErr)
+
+	resultString := string(resultBytes)
+	if expectedString != resultString {
+		t.Fatalf("expected %v got %v", expectedString, resultString)
+	}
+}

--- a/experimental/auth-logic/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrapper_interface_test.go
@@ -22,21 +22,21 @@ import (
 	"testing"
 )
 
-type IntPair struct {
+type intPair struct {
 	x int
 	y int
 }
 
 // Wrapper for pair of ints
-func (p IntPair) Wrap() UnattributedStatement {
+func (p intPair) EmitStatement() UnattributedStatement {
 	return UnattributedStatement{fmt.Sprintf("sum(%v, %v, %v)", p.x, p.y, p.x+p.y)}
 }
 
-func (p IntPair) Identify() Principal {
+func (p intPair) Identify() Principal {
 	return Principal{"Summer"}
 }
 
-func TestSimpleWrapper(t *testing.T) {
+func TestEmitWrapperStatement(t *testing.T) {
 	handleErr := func(err error) {
 		if err != nil {
 			t.Fatalf("test generated error %v", err)
@@ -44,15 +44,15 @@ func TestSimpleWrapper(t *testing.T) {
 		}
 	}
 
-	writeErr := EmitWrapperStatement(IntPair{2, 3}, "wrapped_sum.auth_logic")
+	writeErr := EmitWrapperStatement(intPair{2, 3}, "wrapped_sum.auth_logic")
 	handleErr(writeErr)
 
-	expectedString := "Summer says { sum(2, 3, 5) }"
+	want := "Summer says { sum(2, 3, 5) }"
 	resultBytes, readErr := ioutil.ReadFile("wrapped_sum.auth_logic")
 	handleErr(readErr)
 
-	resultString := string(resultBytes)
-	if expectedString != resultString {
-		t.Fatalf("expected %v got %v", expectedString, resultString)
+	got := string(resultBytes)
+	if got != want {
+		t.Fatalf("got %v want %v", got, want)
 	}
 }


### PR DESCRIPTION
This PR gives an interface for defining the various wrappers that emit authorization logic code as part of using auth logic for the transparent release process.