### PR TITLE
Verifier wrapper

### DIFF
--- a/experimental/auth-logic/BUILD
+++ b/experimental/auth-logic/BUILD
@@ -71,6 +71,21 @@ go_test(
   embed = [":unix_epoch_time_wrapper"],
 )
 
+go_library(
+  name = "verifier_wrapper",
+  importpath = "github.com/project-oak/transparent-release/experimental/auth-logic",
+  srcs = ["verifier_wrapper.go"],
+  embed = [":wrapper_interface"]
+)
+
+go_test(
+  name = "verifier_wrapper_test",
+  importpath = "github.com/project-oak/transparent-release/experimental/auth-logic",
+  srcs = ["verifier_wrapper_test.go"],
+  embed = [":verifier_wrapper"]
+)
+
+
 # This rule runs the authorizaiton logic compiler on "simple.auth_logic"
 # as an input and produces the resulting souffle code and CSVs containing the 
 # results of queries. These outputs are used by "simple_auth_logic_test"

--- a/experimental/auth-logic/BUILD
+++ b/experimental/auth-logic/BUILD
@@ -82,7 +82,10 @@ go_test(
   name = "verifier_wrapper_test",
   importpath = "github.com/project-oak/transparent-release/experimental/auth-logic",
   srcs = ["verifier_wrapper_test.go"],
-  embed = [":verifier_wrapper"]
+  embed = [":verifier_wrapper"],
+  data = [
+    "//experimental/auth-logic/test_data:verifier_wrapper_expected.auth_logic"
+  ]
 )
 
 

--- a/experimental/auth-logic/test_data/BUILD
+++ b/experimental/auth-logic/test_data/BUILD
@@ -1,0 +1,23 @@
+#
+# Copyright 2022 The Project Oak Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(default_visibility = ["//:__subpackages__"])
+
+licenses(["notice"])
+
+exports_files([
+    "verifier_wrapper_expected.auth_logic",
+])

--- a/experimental/auth-logic/test_data/verifier_wrapper_expected.auth_logic
+++ b/experimental/auth-logic/test_data/verifier_wrapper_expected.auth_logic
@@ -1,0 +1,19 @@
+"OakFunctionsLoader::Verifier" says {
+"OakFunctionsLoader::EndorsementFile" canSay "OakFunctionsLoader::Binary" has_expected_hash_from(any_hash, "OakFunctionsLoader::EndorsementFile").
+
+"OakFunctionsLoader::Provenance" canSay "OakFunctionsLoader::Binary" has_expected_hash_from(any_hash, "OakFunctionsLoader::Provenance").
+
+"ProvenanceFileBuilder" canSay any_principal hasProvenance(any_provenance).
+
+"Sha256Wrapper" canSay some_object has_measured_hash(some_hash).
+
+"RekorLogCheck" canSay some_object canActAs "ValidRekorEntry".
+
+"OakFunctionsLoader::Binary" canActas "OakFunctionsLoader" :-
+	"OakFunctionsLoader::Binary" hasProvenance("OakFunctionsLoader::Provenance"),
+	"OakFunctionsLoader::EndorsementFile" canActAs "ValidRekorEntry",
+	"OakFunctionsLoader::Binary" has_expected_hash_from(binary_hash, "OakFunctionsLoader::EndorsementFile"),
+	"OakFunctionsLoader::Binary" has_expected_hash_from(binary_hash, "OakFunctionsLoader::Provenance"),
+	"OakFunctionsLoader::Binary" has_measured_hash(binary_hash).
+
+}

--- a/experimental/auth-logic/unix_epoch_time_wrapper.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper.go
@@ -23,8 +23,7 @@ import (
 
 // This file contains a wrapper that produces the current
 // time as the number of seconds since [the unix
-// epoch](https://en.wikipedia.org/wiki/Unix_time). This wrapper
-// works by running the command `date +%s` on the local machine.
+// epoch](https://en.wikipedia.org/wiki/Unix_time).
 
 type UnixEpochTime struct{}
 

--- a/experimental/auth-logic/unix_epoch_time_wrapper_test.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper_test.go
@@ -51,7 +51,7 @@ func TestUnixEpochTimeWrapper(t *testing.T) {
 	handleErr(readErr)
 	fileReadString := string(fileReadBytes)
 
-	timeTestRegex := regexp.MustCompile("UnixEpochTime says { RealTimeIs\\(([0-9]+)\\). }")
+	timeTestRegex := regexp.MustCompile("UnixEpochTime says {\nRealTimeIs\\(([0-9]+)\\).\n}")
 	match := timeTestRegex.FindStringSubmatch(fileReadString)
 	if len(match) != 2 {
 		t.Errorf("Result of time wrapper did not have valid format. Got: %v.",

--- a/experimental/auth-logic/verifier_wrapper.go
+++ b/experimental/auth-logic/verifier_wrapper.go
@@ -23,28 +23,31 @@ import (
 
 type verifierWrapper struct{ appName string }
 
+// This produces the policy code for checking if a binary can act as an
+// application by aggregating all the evidence from the other parties.
 func (v verifierWrapper) EmitStatement() UnattributedStatement {
-	endorsementPrincipal := fmt.Sprintf("\"%v::EndorsementFile\"", v.appName)
-	provenancePrincipal := fmt.Sprintf("\"%v::Provenance\"", v.appName)
-	binaryPrincipal := fmt.Sprintf("\"%v::Binary\"", v.appName)
-	appPrincipal := fmt.Sprintf("\"%v\"", v.appName)
+	// TODO(#39) consider using a [template](https://pkg.go.dev/text/template) to implement this.
+	endorsementPrincipal := fmt.Sprintf(`"%s::EndorsementFile"`, v.appName)
+	provenancePrincipal := fmt.Sprintf(`"%s::Provenance"`, v.appName)
+	binaryPrincipal := fmt.Sprintf(`"%s::Binary"`, v.appName)
+	appPrincipal := fmt.Sprintf(`"%s"`, v.appName)
 
-  // The verifier needs to import expected hashes from both the endorsement
-  // and provenance files. If we use the same predicate to represent both of 
-  // these statements in this SecPal-based syntax for authorization logic, we 
-  // will lose track of who originated each statement. For example, if we just 
-  // used `Binary has_expected_hash(<hash>)` and the verifier delegates this 
-  // predicate to both the endorsement file and the provenance file, we cannot 
-  // write a policy that looks for the same predicate from both. To work around
-  // this we had a second argument to the predicate to track the original
-  // speaker.
+	// The verifier needs to import expected hashes from both the endorsement
+	// and provenance files. If we use the same predicate to represent both of
+	// these statements in this SecPal-based syntax for authorization logic, we
+	// will lose track of who originated each statement. For example, if we just
+	// used `Binary has_expected_hash(<hash>)` and the verifier delegates this
+	// predicate to both the endorsement file and the provenance file, we cannot
+	// write a policy that looks for the same predicate from both. To work around
+	// this we had a second argument to the predicate to track the original
+	// speaker.
 
 	endorsementHashDelegation :=
-		fmt.Sprintf("%v canSay %v has_expected_hash_from(any_hash, %v).\n",
+		fmt.Sprintf("%s canSay %s has_expected_hash_from(any_hash, %s).\n",
 			endorsementPrincipal, binaryPrincipal, endorsementPrincipal)
 
 	provenanceHashDelegation :=
-		fmt.Sprintf("%v canSay %v has_expected_hash_from(any_hash, %v).\n",
+		fmt.Sprintf("%s canSay %s has_expected_hash_from(any_hash, %s).\n",
 			provenancePrincipal, binaryPrincipal, provenancePrincipal)
 
 	provenanceDelegation :=
@@ -56,15 +59,13 @@ func (v verifierWrapper) EmitStatement() UnattributedStatement {
 	rekorLogCheckDelegation :=
 		"\"RekorLogCheck\" canSay some_object canActAs \"ValidRekorEntry\".\n"
 
-	tab := "    "
-
 	binaryIdentificationRule :=
 		binaryPrincipal + " canActas " + appPrincipal + " :-\n" +
-			tab + binaryPrincipal + " hasProvenance(" + provenancePrincipal + "),\n" +
-			tab + endorsementPrincipal + " canActAs \"ValidRekorEntry\",\n" +
-			tab + binaryPrincipal + " has_expected_hash_from(binary_hash, " + endorsementPrincipal + "),\n" +
-			tab + binaryPrincipal + " has_expected_hash_from(binary_hash, " + provenancePrincipal + "),\n" +
-			tab + binaryPrincipal + " has_measured_hash(binary_hash).\n"
+			"\t" + binaryPrincipal + " hasProvenance(" + provenancePrincipal + "),\n" +
+			"\t" + endorsementPrincipal + " canActAs \"ValidRekorEntry\",\n" +
+			"\t" + binaryPrincipal + " has_expected_hash_from(binary_hash, " + endorsementPrincipal + "),\n" +
+			"\t" + binaryPrincipal + " has_expected_hash_from(binary_hash, " + provenancePrincipal + "),\n" +
+			"\t" + binaryPrincipal + " has_measured_hash(binary_hash).\n"
 
 	return UnattributedStatement{strings.Join([]string{
 		endorsementHashDelegation,

--- a/experimental/auth-logic/verifier_wrapper.go
+++ b/experimental/auth-logic/verifier_wrapper.go
@@ -21,6 +21,14 @@ import (
 	"strings"
 )
 
+const (
+	endorsementHashDelegationInner = "%s canSay %s has_expected_hash_from(any_hash, %s).\n"
+	provenanceHashDelegationInner  = "%s canSay %s has_expected_hash_from(any_hash, %s).\n"
+	provenanceDelegation           = "\"ProvenanceFileBuilder\" canSay any_principal hasProvenance(any_provenance).\n"
+	hashMeasurementDelegation      = "\"Sha256Wrapper\" canSay some_object has_measured_hash(some_hash).\n"
+	rekorLogCheckDelegation        = "\"RekorLogCheck\" canSay some_object canActAs \"ValidRekorEntry\".\n"
+)
+
 type verifierWrapper struct{ appName string }
 
 // This produces the policy code for checking if a binary can act as an
@@ -43,21 +51,12 @@ func (v verifierWrapper) EmitStatement() UnattributedStatement {
 	// speaker.
 
 	endorsementHashDelegation :=
-		fmt.Sprintf("%s canSay %s has_expected_hash_from(any_hash, %s).\n",
+		fmt.Sprintf(endorsementHashDelegationInner,
 			endorsementPrincipal, binaryPrincipal, endorsementPrincipal)
 
 	provenanceHashDelegation :=
-		fmt.Sprintf("%s canSay %s has_expected_hash_from(any_hash, %s).\n",
+		fmt.Sprintf(provenanceHashDelegationInner,
 			provenancePrincipal, binaryPrincipal, provenancePrincipal)
-
-	provenanceDelegation :=
-		"\"ProvenanceFileBuilder\" canSay any_principal hasProvenance(any_provenance).\n"
-
-	hashMeasurementDelegation :=
-		"\"Sha256Wrapper\" canSay some_object has_measured_hash(some_hash).\n"
-
-	rekorLogCheckDelegation :=
-		"\"RekorLogCheck\" canSay some_object canActAs \"ValidRekorEntry\".\n"
 
 	binaryIdentificationRule :=
 		binaryPrincipal + " canActas " + appPrincipal + " :-\n" +

--- a/experimental/auth-logic/verifier_wrapper.go
+++ b/experimental/auth-logic/verifier_wrapper.go
@@ -77,5 +77,5 @@ func (v verifierWrapper) EmitStatement() UnattributedStatement {
 }
 
 func (v verifierWrapper) Identify() Principal {
-	return Principal{fmt.Sprintf("\"%v::Verifier\"", v.appName)}
+	return Principal{fmt.Sprintf(`"%s::Verifier"`, v.appName)}
 }

--- a/experimental/auth-logic/verifier_wrapper.go
+++ b/experimental/auth-logic/verifier_wrapper.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authlogic contains logic and tests for interfacing with the
+// authorization logic compiler
+package authlogic
+
+import (
+	"fmt"
+	"strings"
+)
+
+type verifierWrapper struct{ appName string }
+
+func (v verifierWrapper) EmitStatement() UnattributedStatement {
+	endorsementPrincipal := fmt.Sprintf("\"%v::EndorsementFile\"", v.appName)
+	provenancePrincipal := fmt.Sprintf("\"%v::ProvenanceFile\"", v.appName)
+	binaryPrincipal := fmt.Sprintf("\"%v::Binary\"", v.appName)
+	appPrincipal := fmt.Sprintf("\"%v\"", v.appName)
+
+	provenanceHashDelegation :=
+		fmt.Sprintf("%v canSay expected_hash(%v, any_hash).\n",
+			endorsementPrincipal, provenancePrincipal)
+
+	binaryHashDelegation :=
+		fmt.Sprintf("%v canSay expected_hash(%v, any_hash).\n",
+			endorsementPrincipal, binaryPrincipal)
+
+	provenanceDelegation :=
+		"\"ProvenanceFileBuilder\" canSay any_principal hasProvenance(any_provenance).\n"
+
+	hashMeasurementDelegation :=
+		"\"Sha256Wrapper\" canSay measured_hash(some_object, some_hash).\n"
+
+	rekorLogCheckDelegation :=
+		"\"RekorLogCheck\" canSay some_object canActAs \"ValidRekorEntry\".\n"
+
+	tab := "    "
+
+	binaryIdentificationRule :=
+		binaryPrincipal + " canActas " + appPrincipal + " :-\n" +
+			tab + binaryPrincipal + " hasProvenance(" + provenancePrincipal + "),\n" +
+			tab + endorsementPrincipal + " canActAs \"ValidRekorEntry\",\n" +
+			tab + "expected_hash(" + binaryPrincipal + ", binary_hash),\n" +
+			tab + "measured_hash(" + binaryPrincipal + ", binary_hash),\n" +
+			tab + "expected_hash(" + provenancePrincipal + ", provenance_hash),\n" +
+			tab + "measured_hash(" + provenancePrincipal + ", provenance_hash).\n"
+
+	return UnattributedStatement{strings.Join([]string{
+		provenanceHashDelegation,
+		binaryHashDelegation,
+		provenanceDelegation,
+		hashMeasurementDelegation,
+		rekorLogCheckDelegation,
+		binaryIdentificationRule}[:], "\n")}
+}
+
+func (v verifierWrapper) Identify() Principal {
+	return Principal{fmt.Sprintf("\"%v::Verifier\"", v.appName)}
+}

--- a/experimental/auth-logic/verifier_wrapper_test.go
+++ b/experimental/auth-logic/verifier_wrapper_test.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authlogic contains logic and tests for interfacing with the
+// authorization logic compiler
+package authlogic
+
+import (
+	"testing"
+)
+
+func TestVerifierWrapper(t *testing.T) {
+	want :=
+		`"OakFunctionsLoader::Verifier" says {
+"OakFunctionsLoader::EndorsementFile" canSay expected_hash("OakFunctionsLoader::ProvenanceFile", any_hash).
+
+"OakFunctionsLoader::EndorsementFile" canSay expected_hash("OakFunctionsLoader::Binary", any_hash).
+
+"ProvenanceFileBuilder" canSay any_principal hasProvenance(any_provenance).
+
+"Sha256Wrapper" canSay measured_hash(some_object, some_hash).
+
+"RekorLogCheck" canSay some_object canActAs "ValidRekorEntry".
+
+"OakFunctionsLoader::Binary" canActas "OakFunctionsLoader" :-
+    "OakFunctionsLoader::Binary" hasProvenance("OakFunctionsLoader::ProvenanceFile"),
+    "OakFunctionsLoader::EndorsementFile" canActAs "ValidRekorEntry",
+    expected_hash("OakFunctionsLoader::Binary", binary_hash),
+    measured_hash("OakFunctionsLoader::Binary", binary_hash),
+    expected_hash("OakFunctionsLoader::ProvenanceFile", provenance_hash),
+    measured_hash("OakFunctionsLoader::ProvenanceFile", provenance_hash).
+
+}`
+
+	testVerifier := verifierWrapper{"OakFunctionsLoader"}
+
+	got := wrapAttributed(testVerifier).String()
+
+	if got != want {
+		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
+	}
+
+}

--- a/experimental/auth-logic/verifier_wrapper_test.go
+++ b/experimental/auth-logic/verifier_wrapper_test.go
@@ -17,37 +17,25 @@
 package authlogic
 
 import (
+	"os"
+	"strings"
 	"testing"
 )
 
+const testFilePath = "test_data/verifier_wrapper_expected.auth_logic"
+
 func TestVerifierWrapper(t *testing.T) {
-	want :=
-		`"OakFunctionsLoader::Verifier" says {
-"OakFunctionsLoader::EndorsementFile" canSay "OakFunctionsLoader::Binary" has_expected_hash_from(any_hash, "OakFunctionsLoader::EndorsementFile").
-
-"OakFunctionsLoader::Provenance" canSay "OakFunctionsLoader::Binary" has_expected_hash_from(any_hash, "OakFunctionsLoader::Provenance").
-
-"ProvenanceFileBuilder" canSay any_principal hasProvenance(any_provenance).
-
-"Sha256Wrapper" canSay some_object has_measured_hash(some_hash).
-
-"RekorLogCheck" canSay some_object canActAs "ValidRekorEntry".
-
-"OakFunctionsLoader::Binary" canActas "OakFunctionsLoader" :-
-    "OakFunctionsLoader::Binary" hasProvenance("OakFunctionsLoader::Provenance"),
-    "OakFunctionsLoader::EndorsementFile" canActAs "ValidRekorEntry",
-    "OakFunctionsLoader::Binary" has_expected_hash_from(binary_hash, "OakFunctionsLoader::EndorsementFile"),
-    "OakFunctionsLoader::Binary" has_expected_hash_from(binary_hash, "OakFunctionsLoader::Provenance"),
-    "OakFunctionsLoader::Binary" has_measured_hash(binary_hash).
-
-}`
-
 	testVerifier := verifierWrapper{"OakFunctionsLoader"}
-
 	got := wrapAttributed(testVerifier).String()
 
+	wantFileBytes, err := os.ReadFile(testFilePath)
+	if err != nil {
+		panic(err)
+	}
+	want := strings.TrimSuffix(string(wantFileBytes), "\n")
+
 	if got != want {
-		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
+		t.Errorf("got:\n%v\nwant:\n%v", got, want)
 	}
 
 }

--- a/experimental/auth-logic/verifier_wrapper_test.go
+++ b/experimental/auth-logic/verifier_wrapper_test.go
@@ -23,23 +23,22 @@ import (
 func TestVerifierWrapper(t *testing.T) {
 	want :=
 		`"OakFunctionsLoader::Verifier" says {
-"OakFunctionsLoader::EndorsementFile" canSay expected_hash("OakFunctionsLoader::ProvenanceFile", any_hash).
+"OakFunctionsLoader::EndorsementFile" canSay "OakFunctionsLoader::Binary" has_expected_hash_from(any_hash, "OakFunctionsLoader::EndorsementFile").
 
-"OakFunctionsLoader::EndorsementFile" canSay expected_hash("OakFunctionsLoader::Binary", any_hash).
+"OakFunctionsLoader::Provenance" canSay "OakFunctionsLoader::Binary" has_expected_hash_from(any_hash, "OakFunctionsLoader::Provenance").
 
 "ProvenanceFileBuilder" canSay any_principal hasProvenance(any_provenance).
 
-"Sha256Wrapper" canSay measured_hash(some_object, some_hash).
+"Sha256Wrapper" canSay some_object has_measured_hash(some_hash).
 
 "RekorLogCheck" canSay some_object canActAs "ValidRekorEntry".
 
 "OakFunctionsLoader::Binary" canActas "OakFunctionsLoader" :-
-    "OakFunctionsLoader::Binary" hasProvenance("OakFunctionsLoader::ProvenanceFile"),
+    "OakFunctionsLoader::Binary" hasProvenance("OakFunctionsLoader::Provenance"),
     "OakFunctionsLoader::EndorsementFile" canActAs "ValidRekorEntry",
-    expected_hash("OakFunctionsLoader::Binary", binary_hash),
-    measured_hash("OakFunctionsLoader::Binary", binary_hash),
-    expected_hash("OakFunctionsLoader::ProvenanceFile", provenance_hash),
-    measured_hash("OakFunctionsLoader::ProvenanceFile", provenance_hash).
+    "OakFunctionsLoader::Binary" has_expected_hash_from(binary_hash, "OakFunctionsLoader::EndorsementFile"),
+    "OakFunctionsLoader::Binary" has_expected_hash_from(binary_hash, "OakFunctionsLoader::Provenance"),
+    "OakFunctionsLoader::Binary" has_measured_hash(binary_hash).
 
 }`
 

--- a/experimental/auth-logic/wrapper_interface.go
+++ b/experimental/auth-logic/wrapper_interface.go
@@ -61,7 +61,7 @@ type AuthLogicStatement struct {
 
 // This method produces a string from an AuthLogicStatement
 func (authLogic AuthLogicStatement) String() string {
-	return fmt.Sprintf("%v says { %v }", authLogic.Speaker, authLogic.Statement)
+	return fmt.Sprintf("%v says {\n%v\n}", authLogic.Speaker, authLogic.Statement)
 }
 
 // This interface defines a way of emitting authorization logic statements

--- a/experimental/auth-logic/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrapper_interface_test.go
@@ -29,7 +29,7 @@ type intPair struct {
 
 // Wrapper for pair of ints
 func (p intPair) EmitStatement() UnattributedStatement {
-	return UnattributedStatement{fmt.Sprintf("sum(%v, %v, %v)", p.x, p.y, p.x+p.y)}
+	return UnattributedStatement{fmt.Sprintf("sum(%v, %v, %v).", p.x, p.y, p.x+p.y)}
 }
 
 func (p intPair) Identify() Principal {
@@ -47,7 +47,7 @@ func TestEmitWrapperStatement(t *testing.T) {
 	writeErr := EmitWrapperStatement(intPair{2, 3}, "wrapped_sum.auth_logic")
 	handleErr(writeErr)
 
-	want := "Summer says { sum(2, 3, 5) }"
+	want := "Summer says {\nsum(2, 3, 5).\n}"
 	resultBytes, readErr := ioutil.ReadFile("wrapped_sum.auth_logic")
 	handleErr(readErr)
 


### PR DESCRIPTION
This is a wrapper that takes an application name and produces the verification policy similar to the [Verification Policy Generator here](https://github.com/google-research/raksha/blob/main/rust/tools/authorization-logic/transparent_release_prototype/transparent_release.auth_logic)