### PR TITLE
Wrappers return errors; change speaker interface

### DIFF
--- a/experimental/auth-logic/provenance_build_wrapper.go
+++ b/experimental/auth-logic/provenance_build_wrapper.go
@@ -29,7 +29,8 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	// Unmarshal a provenance struct from the JSON file.
 	provenance, err := slsa.ParseProvenanceFile(pbw.provenanceFilePath)
 	if err != nil {
-		return UnattributedStatement{}, err
+		return UnattributedStatement{},
+			fmt.Errorf("provenance build wrapper couldn't parse provenance file:%s", err)
 	}
 
 	applicationName := provenance.Subject[0].Name
@@ -37,26 +38,30 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	// Generate a BuildConfig struct from the provenance file
 	buildConfig, err := common.LoadBuildConfigFromProvenance(provenance)
 	if err != nil {
-		return UnattributedStatement{}, err
+		return UnattributedStatement{},
+			fmt.Errorf("provenance build wrapper couldn't load build config:%s", err)
 	}
 
 	// Fetch the repository sources from the repository referenced in the
 	// BuildConfig struct.
 	_, err = common.FetchSourcesFromRepo(buildConfig.Repo, buildConfig.CommitHash)
 	if err != nil {
-		return UnattributedStatement{}, err
+		return UnattributedStatement{},
+			fmt.Errorf("provenance build wrapper couldn't fetch repo:%s", err)
 	}
 
 	// Build the binary from the fetched sources.
 	err = buildConfig.Build()
 	if err != nil {
-		return UnattributedStatement{}, err
+		return UnattributedStatement{},
+			fmt.Errorf("provenance build wrapper couldn't build repo:%s", err)
 	}
 
 	// Measure the hash of the binary.
 	measuredBinaryHash, err := buildConfig.ComputeBinarySha256Hash()
 	if err != nil {
-		return UnattributedStatement{}, err
+		return UnattributedStatement{},
+			fmt.Errorf("provenance build wrapper couldn't compute hash:%s", err)
 	}
 
 	return UnattributedStatement{

--- a/experimental/auth-logic/provenance_build_wrapper.go
+++ b/experimental/auth-logic/provenance_build_wrapper.go
@@ -28,42 +28,42 @@ type provenanceBuildWrapper struct{ provenanceFilePath string }
 func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error) {
 	// Unmarshal a provenance struct from the JSON file.
 	provenance, provenanceParseErr := slsa.ParseProvenanceFile(pbw.provenanceFilePath)
-  if provenanceParseErr != nil {
-    return NilUnattributedStatement, provenanceParseErr
-  }
+	if provenanceParseErr != nil {
+		return NilUnattributedStatement, provenanceParseErr
+	}
 
 	applicationName := provenance.Subject[0].Name
 
 	// Generate a BuildConfig struct from the provenance file
 	buildConfig, loadBuildErr := common.LoadBuildConfigFromProvenance(provenance)
-  if loadBuildErr != nil {
-    return NilUnattributedStatement, loadBuildErr
-  }
+	if loadBuildErr != nil {
+		return NilUnattributedStatement, loadBuildErr
+	}
 
 	// Fetch the repository sources from the repository referenced in the
 	// BuildConfig struct.
 	_, repoFetchErr := common.FetchSourcesFromRepo(buildConfig.Repo, buildConfig.CommitHash)
-  if repoFetchErr != nil {
-    return NilUnattributedStatement, repoFetchErr
-  }
+	if repoFetchErr != nil {
+		return NilUnattributedStatement, repoFetchErr
+	}
 
 	// Build the binary from the fetched sources.
 	buildErr := buildConfig.Build()
-  if buildErr != nil {
-    return NilUnattributedStatement, buildErr
-  }
+	if buildErr != nil {
+		return NilUnattributedStatement, buildErr
+	}
 
 	// Measure the hash of the binary.
 	measuredBinaryHash, hashErr := buildConfig.ComputeBinarySha256Hash()
-  if hashErr != nil {
-    return NilUnattributedStatement, hashErr
-  }
+	if hashErr != nil {
+		return NilUnattributedStatement, hashErr
+	}
 
-  statement := UnattributedStatement{
+	statement := UnattributedStatement{
 		fmt.Sprintf("\"%v::Binary\" has_provenance(\"%v::Provenance\").\n",
 			applicationName, applicationName) +
 			fmt.Sprintf("\"%v::Binary\" has_measured_hash(%v).",
 				applicationName, measuredBinaryHash)}
-  return statement, nil
+	return statement, nil
 
 }

--- a/experimental/auth-logic/provenance_build_wrapper.go
+++ b/experimental/auth-logic/provenance_build_wrapper.go
@@ -30,7 +30,7 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	provenance, err := slsa.ParseProvenanceFile(pbw.provenanceFilePath)
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't parse provenance file:%v", err)
+			fmt.Errorf("provenance build wrapper couldn't parse provenance file: %v", err)
 	}
 
 	applicationName := provenance.Subject[0].Name
@@ -39,7 +39,7 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	buildConfig, err := common.LoadBuildConfigFromProvenance(provenance)
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't load build config:%v", err)
+			fmt.Errorf("provenance build wrapper couldn't load build config: %v", err)
 	}
 
 	// Fetch the repository sources from the repository referenced in the
@@ -47,21 +47,21 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	_, err = common.FetchSourcesFromRepo(buildConfig.Repo, buildConfig.CommitHash)
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't fetch repo:%v", err)
+			fmt.Errorf("provenance build wrapper couldn't fetch repo: %v", err)
 	}
 
 	// Build the binary from the fetched sources.
 	err = buildConfig.Build()
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't build repo:%v", err)
+			fmt.Errorf("provenance build wrapper couldn't build repo: %v", err)
 	}
 
 	// Measure the hash of the binary.
 	measuredBinaryHash, err := buildConfig.ComputeBinarySha256Hash()
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't compute hash:%v", err)
+			fmt.Errorf("provenance build wrapper couldn't compute hash: %v", err)
 	}
 
 	return UnattributedStatement{

--- a/experimental/auth-logic/provenance_build_wrapper.go
+++ b/experimental/auth-logic/provenance_build_wrapper.go
@@ -30,7 +30,7 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	provenance, err := slsa.ParseProvenanceFile(pbw.provenanceFilePath)
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't parse provenance file:%s", err)
+			fmt.Errorf("provenance build wrapper couldn't parse provenance file:%v", err)
 	}
 
 	applicationName := provenance.Subject[0].Name
@@ -39,7 +39,7 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	buildConfig, err := common.LoadBuildConfigFromProvenance(provenance)
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't load build config:%s", err)
+			fmt.Errorf("provenance build wrapper couldn't load build config:%v", err)
 	}
 
 	// Fetch the repository sources from the repository referenced in the
@@ -47,25 +47,25 @@ func (pbw provenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	_, err = common.FetchSourcesFromRepo(buildConfig.Repo, buildConfig.CommitHash)
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't fetch repo:%s", err)
+			fmt.Errorf("provenance build wrapper couldn't fetch repo:%v", err)
 	}
 
 	// Build the binary from the fetched sources.
 	err = buildConfig.Build()
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't build repo:%s", err)
+			fmt.Errorf("provenance build wrapper couldn't build repo:%v", err)
 	}
 
 	// Measure the hash of the binary.
 	measuredBinaryHash, err := buildConfig.ComputeBinarySha256Hash()
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("provenance build wrapper couldn't compute hash:%s", err)
+			fmt.Errorf("provenance build wrapper couldn't compute hash:%v", err)
 	}
 
 	return UnattributedStatement{
-		fmt.Sprintf("\"%v::Binary\" has_provenance(\"%v::Provenance\").\n",
+		Contents: fmt.Sprintf("\"%v::Binary\" has_provenance(\"%v::Provenance\").\n",
 			applicationName, applicationName) +
 			fmt.Sprintf("\"%v::Binary\" has_measured_hash(%v).",
 				applicationName, measuredBinaryHash)}, nil

--- a/experimental/auth-logic/provenance_build_wrapper_test.go
+++ b/experimental/auth-logic/provenance_build_wrapper_test.go
@@ -33,11 +33,6 @@ func (p provenanceBuildWrapper) identify() (Principal, error) {
 }
 
 func TestProvenanceBuildWrapper(t *testing.T) {
-	handleErr := func(err error) {
-		if err != nil {
-			t.Fatal("TestProvenanceBuildWrapper encountered fatal error:%s", err)
-		}
-	}
 	want := `"oak_functions_loader::ProvenanceBuilder" says {
 "oak_functions_loader::Binary" has_provenance("oak_functions_loader::Provenance").
 "oak_functions_loader::Binary" has_measured_hash(15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c).
@@ -50,10 +45,14 @@ func TestProvenanceBuildWrapper(t *testing.T) {
 	os.Chdir("../../")
 
 	testProvenance := provenanceBuildWrapper{slsa.SchemaExamplePath}
-	speaker, idErr := testProvenance.identify()
-	handleErr(idErr)
-	statement, emitErr := EmitStatementAs(speaker, testProvenance)
-	handleErr(emitErr)
+	speaker, err := testProvenance.identify()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	statement, err := EmitStatementAs(speaker, testProvenance)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	got := statement.String()
 
 	if got != want {

--- a/experimental/auth-logic/provenance_build_wrapper_test.go
+++ b/experimental/auth-logic/provenance_build_wrapper_test.go
@@ -23,13 +23,15 @@ import (
 )
 
 func (p provenanceBuildWrapper) identify() (Principal, error) {
-	provenance, provenanceErr := slsa.ParseProvenanceFile(p.provenanceFilePath)
-	if provenanceErr != nil {
-		return Principal{}, provenanceErr
+	provenance, err := slsa.ParseProvenanceFile(p.provenanceFilePath)
+	if err != nil {
+		return Principal{}, err 
 	}
 
 	applicationName := provenance.Subject[0].Name
-	return Principal{fmt.Sprintf(`"%v::ProvenanceBuilder"`, applicationName)}, nil
+  return Principal{
+    Contents: fmt.Sprintf(`"%v::ProvenanceBuilder"`, applicationName),
+  }, nil
 }
 
 func TestProvenanceBuildWrapper(t *testing.T) {

--- a/experimental/auth-logic/provenance_build_wrapper_test.go
+++ b/experimental/auth-logic/provenance_build_wrapper_test.go
@@ -35,7 +35,7 @@ func (p provenanceBuildWrapper) identify() (Principal, error) {
 func TestProvenanceBuildWrapper(t *testing.T) {
 	handleErr := func(err error) {
 		if err != nil {
-			panic(err)
+			t.Fatal("TestProvenanceBuildWrapper encountered fatal error:%s", err)
 		}
 	}
 	want := `"oak_functions_loader::ProvenanceBuilder" says {

--- a/experimental/auth-logic/provenance_build_wrapper_test.go
+++ b/experimental/auth-logic/provenance_build_wrapper_test.go
@@ -25,7 +25,7 @@ import (
 func (p provenanceBuildWrapper) identify() (Principal, error) {
 	provenance, provenanceErr := slsa.ParseProvenanceFile(p.provenanceFilePath)
 	if provenanceErr != nil {
-    return NilPrincipal, provenanceErr
+		return NilPrincipal, provenanceErr
 	}
 
 	applicationName := provenance.Subject[0].Name
@@ -50,11 +50,11 @@ func TestProvenanceBuildWrapper(t *testing.T) {
 	os.Chdir("../../")
 
 	testProvenance := provenanceBuildWrapper{slsa.SchemaExamplePath}
-  speaker, idErr := testProvenance.identify()
-  handleErr(idErr)
-  statement, emitErr := EmitStatementAs(speaker, testProvenance)
-  handleErr(emitErr)
-  got := statement.String()
+	speaker, idErr := testProvenance.identify()
+	handleErr(idErr)
+	statement, emitErr := EmitStatementAs(speaker, testProvenance)
+	handleErr(emitErr)
+	got := statement.String()
 
 	if got != want {
 		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)

--- a/experimental/auth-logic/provenance_build_wrapper_test.go
+++ b/experimental/auth-logic/provenance_build_wrapper_test.go
@@ -25,11 +25,11 @@ import (
 func (p provenanceBuildWrapper) identify() (Principal, error) {
 	provenance, provenanceErr := slsa.ParseProvenanceFile(p.provenanceFilePath)
 	if provenanceErr != nil {
-		return NilPrincipal, provenanceErr
+		return Principal{}, provenanceErr
 	}
 
 	applicationName := provenance.Subject[0].Name
-	return Principal{fmt.Sprintf("\"%v::ProvenanceBuilder\"", applicationName)}, nil
+	return Principal{fmt.Sprintf(`"%v::ProvenanceBuilder"`, applicationName)}, nil
 }
 
 func TestProvenanceBuildWrapper(t *testing.T) {

--- a/experimental/auth-logic/provenance_wrapper.go
+++ b/experimental/auth-logic/provenance_wrapper.go
@@ -30,20 +30,20 @@ type provenanceWrapper struct{ filePath string }
 func (p provenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 	provenance, err := slsa.ParseProvenanceFile(p.filePath)
 	if err != nil {
-		return UnattributedStatement{}, err
+    return UnattributedStatement{}, fmt.Errorf(
+      "provenance wrapper couldn't prase provenance file: %v", err)
 	}
 
 	if len(provenance.Subject) < 1 {
-		noSubjectError := fmt.Errorf("Provenance file missing subject")
-		return UnattributedStatement{}, noSubjectError
+		return UnattributedStatement{}, fmt.Errorf("Provenance file missing subject")
 	}
 
 	applicationName := provenance.Subject[0].Name
 	expectedHash, hashOk := provenance.Subject[0].Digest["sha256"]
 
 	if !hashOk {
-		noExpectedHashErr := fmt.Errorf("Provenance file did not give an expected hash")
-		return UnattributedStatement{}, noExpectedHashErr
+		return UnattributedStatement{}, fmt.Errorf(
+      "Provenance file did not give an expected hash")
 	}
 
 	return UnattributedStatement{

--- a/experimental/auth-logic/provenance_wrapper.go
+++ b/experimental/auth-logic/provenance_wrapper.go
@@ -29,14 +29,14 @@ import (
 type provenanceWrapper struct{ filePath string }
 
 func (p provenanceWrapper) EmitStatement() (UnattributedStatement, error) {
-	provenance, provenanceErr := slsa.ParseProvenanceFile(p.filePath)
-	if provenanceErr != nil {
-		return NilUnattributedStatement, provenanceErr
+	provenance, err := slsa.ParseProvenanceFile(p.filePath)
+	if err != nil {
+		return UnattributedStatement{}, err
 	}
 
 	if len(provenance.Subject) < 1 {
 		noSubjectError := errors.New("Provenance file missing subject")
-		return NilUnattributedStatement, noSubjectError
+		return UnattributedStatement{}, noSubjectError
 	}
 
 	applicationName := provenance.Subject[0].Name
@@ -44,12 +44,10 @@ func (p provenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 
 	if !hashOk {
 		noExpectedHashErr := errors.New("Provenance file did not give an expected hash")
-		return NilUnattributedStatement, noExpectedHashErr
+		return UnattributedStatement{}, noExpectedHashErr
 	}
 
-	statement := UnattributedStatement{
+	return UnattributedStatement{
 		Contents: fmt.Sprintf(`expected_hash("%s::Binary", sha256:%s).`, applicationName,
-			expectedHash),
-	}
-	return statement, nil
+			expectedHash)}, nil
 }

--- a/experimental/auth-logic/provenance_wrapper.go
+++ b/experimental/auth-logic/provenance_wrapper.go
@@ -20,7 +20,6 @@ package authlogic
 // about the expected hash for the binary.
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/project-oak/transparent-release/slsa"
@@ -35,7 +34,7 @@ func (p provenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 	}
 
 	if len(provenance.Subject) < 1 {
-		noSubjectError := errors.New("Provenance file missing subject")
+		noSubjectError := fmt.Errorf("Provenance file missing subject")
 		return UnattributedStatement{}, noSubjectError
 	}
 
@@ -43,7 +42,7 @@ func (p provenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 	expectedHash, hashOk := provenance.Subject[0].Digest["sha256"]
 
 	if !hashOk {
-		noExpectedHashErr := errors.New("Provenance file did not give an expected hash")
+		noExpectedHashErr := fmt.Errorf("Provenance file did not give an expected hash")
 		return UnattributedStatement{}, noExpectedHashErr
 	}
 

--- a/experimental/auth-logic/provenance_wrapper_test.go
+++ b/experimental/auth-logic/provenance_wrapper_test.go
@@ -27,14 +27,12 @@ import (
 func (p provenanceWrapper) identify() (Principal, error) {
 	provenance, provenanceErr := slsa.ParseProvenanceFile(p.filePath)
 	if provenanceErr != nil {
-		return NilPrincipal, provenanceErr
+		return Principal{}, provenanceErr
 	}
 
 	applicationName := provenance.Subject[0].Name
-	principal := Principal{
-		Contents: fmt.Sprintf(`"%s::Provenance"`, applicationName),
-	}
-	return principal, nil
+	return Principal{
+		Contents: fmt.Sprintf(`"%s::Provenance"`, applicationName)}, nil
 }
 
 func TestProvenanceWrapper(t *testing.T) {

--- a/experimental/auth-logic/provenance_wrapper_test.go
+++ b/experimental/auth-logic/provenance_wrapper_test.go
@@ -36,11 +36,6 @@ func (p provenanceWrapper) identify() (Principal, error) {
 }
 
 func TestProvenanceWrapper(t *testing.T) {
-	handleErr := func(err error) {
-		if err != nil {
-			t.Fatal("TestProvenanceWrapper encountered fatal error:%s", err)
-		}
-	}
 	want := `"oak_functions_loader::Provenance" says {
 expected_hash("oak_functions_loader::Binary", sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c).
 }`
@@ -52,10 +47,14 @@ expected_hash("oak_functions_loader::Binary", sha256:15dc16c42a4ac9ed77f337a4a30
 	os.Chdir("../../")
 
 	testProvenance := provenanceWrapper{filePath: slsa.SchemaExamplePath}
-	speaker, idErr := testProvenance.identify()
-	handleErr(idErr)
-	statement, emitErr := EmitStatementAs(speaker, testProvenance)
-	handleErr(emitErr)
+	speaker, err := testProvenance.identify()
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	statement, err := EmitStatementAs(speaker, testProvenance)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	got := statement.String()
 
 	if got != want {

--- a/experimental/auth-logic/provenance_wrapper_test.go
+++ b/experimental/auth-logic/provenance_wrapper_test.go
@@ -38,7 +38,7 @@ func (p provenanceWrapper) identify() (Principal, error) {
 func TestProvenanceWrapper(t *testing.T) {
 	handleErr := func(err error) {
 		if err != nil {
-			panic(err)
+			t.Fatal("TestProvenanceWrapper encountered fatal error:%s", err)
 		}
 	}
 	want := `"oak_functions_loader::Provenance" says {

--- a/experimental/auth-logic/unix_epoch_time_wrapper.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper.go
@@ -27,7 +27,10 @@ import (
 
 type UnixEpochTime struct{}
 
-func (timeWrapper UnixEpochTime) EmitStatement() UnattributedStatement {
+func (timeWrapper UnixEpochTime) EmitStatement() (UnattributedStatement, error) {
 	epochTime := time.Now().Unix()
-	return UnattributedStatement{Contents: fmt.Sprintf("RealTimeIs(%v).", epochTime)}
+	statement := UnattributedStatement{
+		Contents: fmt.Sprintf("RealTimeIs(%v).", epochTime),
+	}
+	return statement, nil
 }

--- a/experimental/auth-logic/unix_epoch_time_wrapper.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper.go
@@ -29,8 +29,6 @@ type UnixEpochTime struct{}
 
 func (timeWrapper UnixEpochTime) EmitStatement() (UnattributedStatement, error) {
 	epochTime := time.Now().Unix()
-	statement := UnattributedStatement{
-		Contents: fmt.Sprintf("RealTimeIs(%v).", epochTime),
-	}
-	return statement, nil
+	return UnattributedStatement{
+		Contents: fmt.Sprintf("RealTimeIs(%v).", epochTime)}, nil
 }

--- a/experimental/auth-logic/unix_epoch_time_wrapper.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper.go
@@ -30,5 +30,6 @@ type UnixEpochTime struct{}
 func (timeWrapper UnixEpochTime) EmitStatement() (UnattributedStatement, error) {
 	epochTime := time.Now().Unix()
 	return UnattributedStatement{
-		Contents: fmt.Sprintf("RealTimeIs(%v).", epochTime)}, nil
+		Contents: fmt.Sprintf("RealTimeIs(%v).", epochTime),
+	}, nil
 }

--- a/experimental/auth-logic/unix_epoch_time_wrapper_test.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper_test.go
@@ -34,16 +34,11 @@ func (time UnixEpochTime) identify() Principal {
 }
 
 func TestUnixEpochTimeWrapper(t *testing.T) {
-	handleErr := func(err error) {
-		if err != nil {
-			t.Fatalf("test generated error %v", err)
-			panic(err)
-		}
-	}
-
 	testWrapper := UnixEpochTime{}
-	statement, emitErr := EmitStatementAs(testWrapper.identify(), testWrapper)
-	handleErr(emitErr)
+	statement, err := EmitStatementAs(testWrapper.identify(), testWrapper)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	got := statement.String()
 
 	timeTestRegex := regexp.MustCompile("UnixEpochTime says {\nRealTimeIs\\(([0-9]+)\\).\n}")
@@ -52,8 +47,10 @@ func TestUnixEpochTimeWrapper(t *testing.T) {
 		t.Errorf("Result of time wrapper did not have valid format. Got: %v.", got)
 	}
 
-	timeValue, conversionErr := strconv.Atoi(match[1])
-	handleErr(conversionErr)
+	timeValue, err := strconv.Atoi(match[1])
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	if timeValue < pastDate {
 		t.Errorf("The emitted current time %v, already happened", timeValue)

--- a/experimental/auth-logic/unix_epoch_time_wrapper_test.go
+++ b/experimental/auth-logic/unix_epoch_time_wrapper_test.go
@@ -17,7 +17,6 @@
 package authlogic
 
 import (
-	"io/ioutil"
 	"regexp"
 	"strconv"
 	"testing"
@@ -30,7 +29,7 @@ const (
 	futureDate = 33197947200
 )
 
-func (time UnixEpochTime) Identify() Principal {
+func (time UnixEpochTime) identify() Principal {
 	return Principal{Contents: "UnixEpochTime"}
 }
 
@@ -42,20 +41,15 @@ func TestUnixEpochTimeWrapper(t *testing.T) {
 		}
 	}
 
-	// Write a statement from the time wrapper to a file
-	writeErr := EmitWrapperStatement(UnixEpochTime{}, "wrapped_time.auth_logic")
-	handleErr(writeErr)
-
-	// Read the contents of the file
-	fileReadBytes, readErr := ioutil.ReadFile("wrapped_time.auth_logic")
-	handleErr(readErr)
-	fileReadString := string(fileReadBytes)
+	testWrapper := UnixEpochTime{}
+	statement, emitErr := EmitStatementAs(testWrapper.identify(), testWrapper)
+	handleErr(emitErr)
+	got := statement.String()
 
 	timeTestRegex := regexp.MustCompile("UnixEpochTime says {\nRealTimeIs\\(([0-9]+)\\).\n}")
-	match := timeTestRegex.FindStringSubmatch(fileReadString)
+	match := timeTestRegex.FindStringSubmatch(got)
 	if len(match) != 2 {
-		t.Errorf("Result of time wrapper did not have valid format. Got: %v.",
-			fileReadString)
+		t.Errorf("Result of time wrapper did not have valid format. Got: %v.", got)
 	}
 
 	timeValue, conversionErr := strconv.Atoi(match[1])

--- a/experimental/auth-logic/verifier_wrapper.go
+++ b/experimental/auth-logic/verifier_wrapper.go
@@ -33,7 +33,7 @@ type verifierWrapper struct{ appName string }
 
 // This produces the policy code for checking if a binary can act as an
 // application by aggregating all the evidence from the other parties.
-func (v verifierWrapper) EmitStatement() UnattributedStatement {
+func (v verifierWrapper) EmitStatement() (UnattributedStatement, error) {
 	// TODO(#39) consider using a [template](https://pkg.go.dev/text/template) to implement this.
 	endorsementPrincipal := fmt.Sprintf(`"%s::EndorsementFile"`, v.appName)
 	provenancePrincipal := fmt.Sprintf(`"%s::Provenance"`, v.appName)
@@ -66,15 +66,12 @@ func (v verifierWrapper) EmitStatement() UnattributedStatement {
 			"\t" + binaryPrincipal + " has_expected_hash_from(binary_hash, " + provenancePrincipal + "),\n" +
 			"\t" + binaryPrincipal + " has_measured_hash(binary_hash).\n"
 
-	return UnattributedStatement{Contents: strings.Join([]string{
+	statement := UnattributedStatement{Contents: strings.Join([]string{
 		endorsementHashDelegation,
 		provenanceHashDelegation,
 		provenanceDelegation,
 		hashMeasurementDelegation,
 		rekorLogCheckDelegation,
 		binaryIdentificationRule}[:], "\n")}
-}
-
-func (v verifierWrapper) Identify() Principal {
-  return Principal{Contents: fmt.Sprintf(`"%s::Verifier"`, v.appName)}
+	return statement, nil
 }

--- a/experimental/auth-logic/verifier_wrapper.go
+++ b/experimental/auth-logic/verifier_wrapper.go
@@ -66,12 +66,11 @@ func (v verifierWrapper) EmitStatement() (UnattributedStatement, error) {
 			"\t" + binaryPrincipal + " has_expected_hash_from(binary_hash, " + provenancePrincipal + "),\n" +
 			"\t" + binaryPrincipal + " has_measured_hash(binary_hash).\n"
 
-	statement := UnattributedStatement{Contents: strings.Join([]string{
+	return UnattributedStatement{Contents: strings.Join([]string{
 		endorsementHashDelegation,
 		provenanceHashDelegation,
 		provenanceDelegation,
 		hashMeasurementDelegation,
 		rekorLogCheckDelegation,
-		binaryIdentificationRule}[:], "\n")}
-	return statement, nil
+		binaryIdentificationRule}[:], "\n")}, nil
 }

--- a/experimental/auth-logic/verifier_wrapper_test.go
+++ b/experimental/auth-logic/verifier_wrapper_test.go
@@ -33,7 +33,6 @@ func TestVerifierWrapper(t *testing.T) {
 	handleErr := func(err error) {
 		if err != nil {
 			t.Fatalf("test generated error %v", err)
-			panic(err)
 		}
 	}
 

--- a/experimental/auth-logic/verifier_wrapper_test.go
+++ b/experimental/auth-logic/verifier_wrapper_test.go
@@ -30,19 +30,17 @@ func (v verifierWrapper) identify() Principal {
 const testFilePath = "test_data/verifier_wrapper_expected.auth_logic"
 
 func TestVerifierWrapper(t *testing.T) {
-	handleErr := func(err error) {
-		if err != nil {
-			t.Fatalf("test generated error %v", err)
-		}
-	}
-
 	testWrapper := verifierWrapper{appName: "OakFunctionsLoader"}
-	statement, emitErr := EmitStatementAs(testWrapper.identify(), testWrapper)
-	handleErr(emitErr)
+	statement, err := EmitStatementAs(testWrapper.identify(), testWrapper)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	got := statement.String()
 
-	wantFileBytes, readFileErr := os.ReadFile(testFilePath)
-	handleErr(readFileErr)
+	wantFileBytes, err := os.ReadFile(testFilePath)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 	want := strings.TrimSuffix(string(wantFileBytes), "\n")
 
 	if got != want {

--- a/experimental/auth-logic/wrapper_interface.go
+++ b/experimental/auth-logic/wrapper_interface.go
@@ -18,7 +18,7 @@ package authlogic
 
 import (
 	"fmt"
-  "os"
+	"os"
 )
 
 // This struct represents an authorization logic statement (or sequence of
@@ -39,7 +39,7 @@ type UnattributedStatement struct {
 
 // This is an empty unattributed statement. It is defined as a var rather
 // than a constant because golang does not have support for const structs
-var NilUnattributedStatement = UnattributedStatement{Contents:""}
+var NilUnattributedStatement = UnattributedStatement{Contents: ""}
 
 // This method gets a string for an UnattributedStatement.
 func (statement UnattributedStatement) String() string {
@@ -51,7 +51,7 @@ type Principal struct {
 	Contents string
 }
 
-var NilPrincipal = Principal{Contents:""}
+var NilPrincipal = Principal{Contents: ""}
 
 // This method gets a string for a Principal.
 func (principal Principal) String() string {
@@ -66,8 +66,8 @@ type AuthLogicStatement struct {
 }
 
 var NilAuthLogicStatement = AuthLogicStatement{
-  Speaker: NilPrincipal, 
-  Statement: NilUnattributedStatement}
+	Speaker:   NilPrincipal,
+	Statement: NilUnattributedStatement}
 
 // This method produces a string from an AuthLogicStatement
 func (authLogic AuthLogicStatement) String() string {
@@ -77,18 +77,18 @@ func (authLogic AuthLogicStatement) String() string {
 // This interface defines a way of emitting authorization logic statements
 // that are not attributed to any principal. A wrapper might implement this
 // method by parsing a file in a particular format or checking the system clock
-// before emitting an authorization logic statement. These do not include 
+// before emitting an authorization logic statement. These do not include
 // speakers.
 type Wrapper interface {
 	EmitStatement() (UnattributedStatement, error)
 }
 
 func EmitStatementAs(principal Principal, wrapper Wrapper) (AuthLogicStatement, error) {
-  statement, statementErr := wrapper.EmitStatement()
-  if statementErr != nil {
-    return NilAuthLogicStatement, statementErr
-  }
-  return AuthLogicStatement{Speaker: principal, Statement: statement}, statementErr
+	statement, statementErr := wrapper.EmitStatement()
+	if statementErr != nil {
+		return NilAuthLogicStatement, statementErr
+	}
+	return AuthLogicStatement{Speaker: principal, Statement: statement}, statementErr
 }
 
 func EmitAuthLogicToFile(authLogic AuthLogicStatement, filepath string) error {

--- a/experimental/auth-logic/wrapper_interface.go
+++ b/experimental/auth-logic/wrapper_interface.go
@@ -74,11 +74,11 @@ type Wrapper interface {
 }
 
 func EmitStatementAs(principal Principal, wrapper Wrapper) (AuthLogicStatement, error) {
-	statement, statementErr := wrapper.EmitStatement()
-	if statementErr != nil {
-		return AuthLogicStatement{}, statementErr
+	statement, err := wrapper.EmitStatement()
+	if err != nil {
+		return AuthLogicStatement{}, err
 	}
-	return AuthLogicStatement{Speaker: principal, Statement: statement}, statementErr
+	return AuthLogicStatement{Speaker: principal, Statement: statement}, nil
 }
 
 func EmitAuthLogicToFile(authLogic AuthLogicStatement, filepath string) error {

--- a/experimental/auth-logic/wrapper_interface.go
+++ b/experimental/auth-logic/wrapper_interface.go
@@ -37,10 +37,6 @@ type UnattributedStatement struct {
 	Contents string
 }
 
-// This is an empty unattributed statement. It is defined as a var rather
-// than a constant because golang does not have support for const structs
-var NilUnattributedStatement = UnattributedStatement{Contents: ""}
-
 // This method gets a string for an UnattributedStatement.
 func (statement UnattributedStatement) String() string {
 	return statement.Contents
@@ -50,8 +46,6 @@ func (statement UnattributedStatement) String() string {
 type Principal struct {
 	Contents string
 }
-
-var NilPrincipal = Principal{Contents: ""}
 
 // This method gets a string for a Principal.
 func (principal Principal) String() string {
@@ -64,10 +58,6 @@ type AuthLogicStatement struct {
 	Speaker   Principal
 	Statement UnattributedStatement
 }
-
-var NilAuthLogicStatement = AuthLogicStatement{
-	Speaker:   NilPrincipal,
-	Statement: NilUnattributedStatement}
 
 // This method produces a string from an AuthLogicStatement
 func (authLogic AuthLogicStatement) String() string {
@@ -86,7 +76,7 @@ type Wrapper interface {
 func EmitStatementAs(principal Principal, wrapper Wrapper) (AuthLogicStatement, error) {
 	statement, statementErr := wrapper.EmitStatement()
 	if statementErr != nil {
-		return NilAuthLogicStatement, statementErr
+		return AuthLogicStatement{}, statementErr
 	}
 	return AuthLogicStatement{Speaker: principal, Statement: statement}, statementErr
 }

--- a/experimental/auth-logic/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrapper_interface_test.go
@@ -29,7 +29,7 @@ type intPair struct {
 
 // Wrapper for pair of ints
 func (p intPair) EmitStatement() (UnattributedStatement, error) {
-	contents := fmt.Sprintf("sum(%v, %v, %v).", p.x, p.y, p.x+p.y)
+	contents := fmt.Sprintf("sum(%d, %d, %d).", p.x, p.y, p.x+p.y)
 	return UnattributedStatement{Contents: contents}, nil
 }
 
@@ -38,22 +38,21 @@ func (p intPair) Identify() Principal {
 }
 
 func TestEmitWrapperStatement(t *testing.T) {
-	handleErr := func(err error) {
-		if err != nil {
-			t.Fatalf("test generated error %v", err)
-			panic(err)
-		}
+	statement, err := EmitStatementAs(Principal{"Summer"}, intPair{2, 3})
+	if err != nil {
+		t.Fatalf("%v", err)
 	}
 
-	statement, emitErr := EmitStatementAs(Principal{"Summer"}, intPair{2, 3})
-	handleErr(emitErr)
-
-	writeErr := EmitAuthLogicToFile(statement, "wrapped_sum.auth_logic")
-	handleErr(writeErr)
+	err = EmitAuthLogicToFile(statement, "wrapped_sum.auth_logic")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	want := "Summer says {\nsum(2, 3, 5).\n}"
-	resultBytes, readErr := ioutil.ReadFile("wrapped_sum.auth_logic")
-	handleErr(readErr)
+	resultBytes, err := ioutil.ReadFile("wrapped_sum.auth_logic")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
 
 	got := string(resultBytes)
 	if got != want {

--- a/experimental/auth-logic/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrapper_interface_test.go
@@ -28,8 +28,9 @@ type intPair struct {
 }
 
 // Wrapper for pair of ints
-func (p intPair) EmitStatement() UnattributedStatement {
-	return UnattributedStatement{fmt.Sprintf("sum(%v, %v, %v).", p.x, p.y, p.x+p.y)}
+func (p intPair) EmitStatement() (UnattributedStatement, error) {
+  contents := fmt.Sprintf("sum(%v, %v, %v).", p.x, p.y, p.x+p.y)
+  return UnattributedStatement{Contents: contents}, nil
 }
 
 func (p intPair) Identify() Principal {
@@ -44,7 +45,10 @@ func TestEmitWrapperStatement(t *testing.T) {
 		}
 	}
 
-	writeErr := EmitWrapperStatement(intPair{2, 3}, "wrapped_sum.auth_logic")
+  statement, emitErr := EmitStatementAs(Principal{"Summer"}, intPair{2, 3})
+  handleErr(emitErr)
+
+	writeErr := EmitAuthLogicToFile(statement, "wrapped_sum.auth_logic")
 	handleErr(writeErr)
 
 	want := "Summer says {\nsum(2, 3, 5).\n}"

--- a/experimental/auth-logic/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrapper_interface_test.go
@@ -29,8 +29,8 @@ type intPair struct {
 
 // Wrapper for pair of ints
 func (p intPair) EmitStatement() (UnattributedStatement, error) {
-  contents := fmt.Sprintf("sum(%v, %v, %v).", p.x, p.y, p.x+p.y)
-  return UnattributedStatement{Contents: contents}, nil
+	contents := fmt.Sprintf("sum(%v, %v, %v).", p.x, p.y, p.x+p.y)
+	return UnattributedStatement{Contents: contents}, nil
 }
 
 func (p intPair) Identify() Principal {
@@ -45,8 +45,8 @@ func TestEmitWrapperStatement(t *testing.T) {
 		}
 	}
 
-  statement, emitErr := EmitStatementAs(Principal{"Summer"}, intPair{2, 3})
-  handleErr(emitErr)
+	statement, emitErr := EmitStatementAs(Principal{"Summer"}, intPair{2, 3})
+	handleErr(emitErr)
 
 	writeErr := EmitAuthLogicToFile(statement, "wrapped_sum.auth_logic")
 	handleErr(writeErr)


### PR DESCRIPTION
fixes #40 

Removes `IdentifiableWrapper` interface that @tiziano88 does not like as described here: #41 