### PR TITLE
Wrapper for Endorsement Files

### DIFF
--- a/experimental/auth-logic/BUILD
+++ b/experimental/auth-logic/BUILD
@@ -135,6 +135,16 @@ go_library(
   embed = [":wrapper_interface"]
 )
 
+go_test(
+  name = "endorsement_wrapper_test",
+  size = "small",
+  srcs = ["endorsement_wrapper_test.go"],
+  data = [
+      "//schema/amber-endorsement/v1:example.json"
+  ],
+  embed = [":endorsement_wrapper"]
+)
+
 # This rule runs the authorizaiton logic compiler on "simple.auth_logic"
 # as an input and produces the resulting souffle code and CSVs containing the 
 # results of queries. These outputs are used by "simple_auth_logic_test"

--- a/experimental/auth-logic/BUILD
+++ b/experimental/auth-logic/BUILD
@@ -128,6 +128,13 @@ go_test(
   embed = [":provenance_build_wrapper"]
 )
 
+go_library(
+  name = "endorsement_wrapper",
+  importpath = "github.com/project-oak/transparent-release/experimental/auth-logic",
+  srcs = ["endorsement_wrapper.go"],
+  embed = [":wrapper_interface"]
+)
+
 # This rule runs the authorizaiton logic compiler on "simple.auth_logic"
 # as an input and produces the resulting souffle code and CSVs containing the 
 # results of queries. These outputs are used by "simple_auth_logic_test"

--- a/experimental/auth-logic/endorsement_wrapper.go
+++ b/experimental/auth-logic/endorsement_wrapper.go
@@ -59,7 +59,7 @@ type ValidatedEndorsement struct {
 	ExpiryTime  time.Time
 }
 
-// This parses an endorsement file (in JSON) and
+// ParseEndorsementFile parses an endorsement file (in JSON) and
 // produces an `Endorsement` data structure.
 func ParseEndorsementFile(path string) (*Endorsement, error) {
 	endorsementBytes, err := ioutil.ReadFile(path)

--- a/experimental/auth-logic/endorsement_wrapper.go
+++ b/experimental/auth-logic/endorsement_wrapper.go
@@ -142,7 +142,7 @@ func (ew endorsementWrapper) EmitStatement() (UnattributedStatement, error) {
 		binaryPrincipal, validatedEndorsement.Sha256, endorsementWrapperName)
 
 	expirationCondition := fmt.Sprintf(
-		`RealTimeIs(current_time), current_time > %d, current_time < %d`,
+		`RealTimeIs(current_time), current_time >= %d, current_time < %d`,
 		validatedEndorsement.ReleaseTime.Unix(),
 		validatedEndorsement.ExpiryTime.Unix())
 

--- a/experimental/auth-logic/endorsement_wrapper.go
+++ b/experimental/auth-logic/endorsement_wrapper.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"regexp"
 	"time"
 )
 
@@ -53,6 +52,15 @@ type ValidityPeriod struct {
 	ExpiryTime  string `json:"expiryTime"`
 }
 
+type ValidatedEndorsement struct {
+	Name        string
+	Sha256      string
+	ReleaseTime time.Time
+	ExpiryTime  time.Time
+}
+
+// This parses an endorsement file (in JSON) and
+// produces an `Endorsement` data structure.
 func ParseEndorsementFile(path string) (*Endorsement, error) {
 	endorsementBytes, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -70,26 +78,47 @@ func ParseEndorsementFile(path string) (*Endorsement, error) {
 	return &endorsement, nil
 }
 
-func (ew endorsementWrapper) getShortAppName() (string, error) {
-	endorsement, err := ParseEndorsementFile(ew.endorsementFilePath)
-	if err != nil {
-		return "", fmt.Errorf(
-			"getShortAppName couldn't parse endorsement file: %v", err)
-	}
+func (endorsement Endorsement) GenerateValidatedEndorsement() (ValidatedEndorsement, error) {
 
 	if len(endorsement.Subject) < 1 {
-		return "", fmt.Errorf("Endorsement file missing subject: %s",
-			ew.endorsementFilePath)
+		return ValidatedEndorsement{},
+			fmt.Errorf("Endorsement file missing subject: %s", endorsement)
 	}
-
 	appName := endorsement.Subject[0].Name
-	nameExtractRegex := regexp.MustCompile("(.+)-[0-9]+")
-	match := nameExtractRegex.FindStringSubmatch(appName)
-	if len(match) != 2 {
-		return "", fmt.Errorf("Couldn't extract app name from: %s", appName)
+
+	expectedHash, ok := endorsement.Subject[0].Digest["sha256"]
+	if !ok {
+		return ValidatedEndorsement{},
+			fmt.Errorf("Endorsement file did not give an expected hash: %s",
+				endorsement)
 	}
 
-	return match[1], nil
+	releaseTimeText := endorsement.Predicate.ValidityPeriod.ReleaseTime
+	releaseTime, err := time.Parse(time.RFC3339, releaseTimeText)
+	if err != nil {
+		return ValidatedEndorsement{},
+			fmt.Errorf("Endorsement file release time had invalid format: %v", err)
+	}
+
+	expiryTimeText := endorsement.Predicate.ValidityPeriod.ExpiryTime
+	expiryTime, err := time.Parse(time.RFC3339, expiryTimeText)
+	if err != nil {
+		return ValidatedEndorsement{},
+			fmt.Errorf("Endorsement file expiry time had invalid format: %v", err)
+	}
+
+	if err != nil {
+		return ValidatedEndorsement{},
+			fmt.Errorf("Endorsement file wrapper couldn't get app name: %v", err)
+	}
+
+	return ValidatedEndorsement{
+		Name:        appName,
+		Sha256:      expectedHash,
+		ReleaseTime: releaseTime,
+		ExpiryTime:  expiryTime,
+	}, nil
+
 }
 
 func (ew endorsementWrapper) EmitStatement() (UnattributedStatement, error) {
@@ -99,49 +128,26 @@ func (ew endorsementWrapper) EmitStatement() (UnattributedStatement, error) {
 			fmt.Errorf("Endorsement file wrapper couldn't parse file: %v", err)
 	}
 
-	if len(endorsement.Subject) < 1 {
-		return UnattributedStatement{},
-			fmt.Errorf("Endorsement file missing subject: %s", ew.endorsementFilePath)
-	}
-
-	expectedHash, ok := endorsement.Subject[0].Digest["sha256"]
-	if !ok {
-		return UnattributedStatement{},
-			fmt.Errorf("Endorsement file did not give an expected hash: %s",
-				ew.endorsementFilePath)
-	}
-
-	releaseTimeText := endorsement.Predicate.ValidityPeriod.ReleaseTime
-	releaseTime, err := time.Parse(time.RFC3339, releaseTimeText)
+	validatedEndorsement, err := endorsement.GenerateValidatedEndorsement()
 	if err != nil {
 		return UnattributedStatement{},
-			fmt.Errorf("Endorsement file release time had invalid format: %v", err)
+			fmt.Errorf("Endorsement file wrapper couldn't validate endorsement: %v", err)
 	}
 
-	expiryTimeText := endorsement.Predicate.ValidityPeriod.ExpiryTime
-	expiryTime, err := time.Parse(time.RFC3339, expiryTimeText)
-	if err != nil {
-		return UnattributedStatement{},
-			fmt.Errorf("Endorsement file expiry time had invalid format: %v", err)
-	}
-
-	appName, err := ew.getShortAppName()
-	if err != nil {
-		return UnattributedStatement{},
-			fmt.Errorf("Endorsement file wrapper couldn't get short name: %v", err)
-	}
-
-	binaryPrincipal := fmt.Sprintf(`"%s::Binary"`, appName)
-	endorsementWrapperName := fmt.Sprintf(`"%s::EndorsementFile"`, appName)
+	binaryPrincipal := fmt.Sprintf(`"%s::Binary"`, validatedEndorsement.Name)
+	endorsementWrapperName := fmt.Sprintf(`"%s::EndorsementFile"`,
+		validatedEndorsement.Name)
 
 	hasExpectedHash := fmt.Sprintf(`%s has_expected_hash_from("sha256:%s", %s)`,
-		binaryPrincipal, expectedHash, endorsementWrapperName)
+		binaryPrincipal, validatedEndorsement.Sha256, endorsementWrapperName)
 
 	expirationCondition := fmt.Sprintf(
 		`RealTimeIs(current_time), current_time > %d, current_time < %d`,
-		releaseTime.Unix(), expiryTime.Unix())
+		validatedEndorsement.ReleaseTime.Unix(),
+		validatedEndorsement.ExpiryTime.Unix())
 
-	hashRule := fmt.Sprintf("%s :-\n    %s.\n", hasExpectedHash, expirationCondition)
+	hashRule := fmt.Sprintf("%s :-\n    %s.\n", hasExpectedHash,
+		expirationCondition)
 
 	timePrincipalName := `"UnixEpochTime"`
 	timeDelegation := fmt.Sprintf("%s canSay RealTimeIs(any_time).\n",

--- a/experimental/auth-logic/endorsement_wrapper.go
+++ b/experimental/auth-logic/endorsement_wrapper.go
@@ -1,0 +1,101 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authlogic contains logic and tests for interfacing with the
+// authorization logic compiler
+package authlogic
+
+import (
+  "encoding/json"
+  "errors"
+  "os"
+  "fmt"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+type endorsementWrapper struct{ endorsementFilePath string }
+
+// Struct to parse the Endorsement File
+type Endorsement struct {
+	Type          string    `json:"_type"`
+	Subject       []Subject `json:"subject"`
+	PredicateType string    `json:"predicateType"`
+	Predicate     Predicate `json:"predicate"`
+}
+
+// Struct to parse the Subject of the endorsement file.
+type Subject struct {
+	Name   string `json:"name"`
+	Digest Digest `json:"digest"`
+}
+
+// Struct to parse a Digest from the endorsement file.
+type Digest map[string]string
+
+// Struct to parse the Predicate in the endorsement file.
+type Predicate struct {
+  ValidityPeriod ValidityPeriod `json:"validityPeriod"`
+}
+
+type ValidityPeriod struct {
+  ReleaseTime string `json:"releaseTime"`
+  ExpiryTime string `json:"expiryTime"`
+}
+
+func ParseEndorsmentFile(path string) (*Endorsement, error) {
+	endorsementBytes , readErr := ioutil.ReadFile(path)
+	if readErr != nil {
+		return nil, fmt.Errorf("could not read the endorsement file: %v", readErr)
+	}
+
+	var endorsement Endorsement
+
+	unmarshalErr := json.Unmarshal(endorsementBytes, &endorsement)
+	if unmarshalErr != nil {
+		return nil, fmt.Errorf("could not unmarshal the endorsement file:\n%v", unmarshalErr)
+	}
+
+	return &endorsement, nil
+}
+
+func (ew endorsementWrapper) EmitStatement() (UnattributedStatement, error) {
+  endorsement, jsonParseErr := ParseEndorsementFile(ew.endorsementFilePath)
+  if jsonParseErr != nil {
+    return NilUnattributedStatement, nil
+  }
+
+  if len(endorsement.Subject) < 1 {
+    noSubjectError := errors.New("Endorsement file missing subject")
+    return NilUnattributedStatement, noSubjectError
+  }
+
+  appName := endorsement.Subject[0].Name
+
+	expectedHash, hashOk := endorsement.Subject[0].Digest["sha256"]
+  if !hashOk {
+		noExpectedHashErr := errors.New("Endorsement file did not give an expected hash")
+    return NilUnattributedStatement, noExpectedHashErr
+  }
+
+  releaseTime := endorsement.Predicate.ValidityPeriod.ReleaseTime
+  expiryTime := endorsement.Predicate.ValidityPeriod.ExpiryTime
+
+  statement := UnattributedStatement {
+    Contents: fmt.Sprintf("%s\n%s\n%s,\n%s",
+      endorsement.appName, endorsement.digest,
+      releaseTime, expiryTime),
+  }
+  return statement, nil
+}

--- a/experimental/auth-logic/endorsement_wrapper_test.go
+++ b/experimental/auth-logic/endorsement_wrapper_test.go
@@ -24,7 +24,7 @@ const testEndorsementPath = "../../schema/amber-endorsement/v1/example.json"
 func TestEndorsementWrapper(t *testing.T) {
 	want := `"oak_functions_loader-0f2189703c57845e09d8ab89164a4041c0af0a62::EndorsementFile" says {
 "oak_functions_loader-0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c", "oak_functions_loader-0f2189703c57845e09d8ab89164a4041c0af0a62::EndorsementFile") :-
-    RealTimeIs(current_time), current_time > 1643710850, current_time < 1646130050.
+    RealTimeIs(current_time), current_time >= 1643710850, current_time < 1646130050.
 "UnixEpochTime" canSay RealTimeIs(any_time).
 
 }`

--- a/experimental/auth-logic/endorsement_wrapper_test.go
+++ b/experimental/auth-logic/endorsement_wrapper_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Project Oak Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authlogic
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+const testEndorsementPath := "../../schema/amber-endorsement/v1/example.json"
+
+func (ew endorsementWrapper) identify() (Principal, error) {
+  endorsement, parseErr := parseJSONFromFile(ew.endorsementFilePath)
+  return Principal{Contents: endorsement.appName}, parseErr
+}
+
+func TestEndorsementWrapper(t *testing.T) {
+	handleErr := func(err error) {
+		if err != nil {
+			panic(err)
+		}
+	}
+
+  want := ""
+
+  testEndorsementWrapper := endorsementWrapper{
+    endorsementFilePath: testEndorsementPath,
+  }
+
+  speaker, idErr := testEndorsementWrapper.identify()
+  handleErr(idErr)
+
+  
+	if got != want {
+		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
+	}
+
+}

--- a/experimental/auth-logic/endorsement_wrapper_test.go
+++ b/experimental/auth-logic/endorsement_wrapper_test.go
@@ -15,38 +15,37 @@
 package authlogic
 
 import (
-  "fmt"
+	"fmt"
 	"testing"
 )
 
 const testEndorsementPath = "../../schema/amber-endorsement/v1/example.json"
 
 func TestEndorsementWrapper(t *testing.T) {
-	handleErr := func(err error) {
-		if err != nil {
-			panic(err)
-		}
-	}
-
-  want := `"oak_functions_loader::EndorsementFile" says {
+	want := `"oak_functions_loader::EndorsementFile" says {
 "oak_functions_loader::Binary" has_expected_hash_from("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c", "oak_functions_loader::EndorsementFile") :-
     RealTimeIs(current_time), current_time > 1643710850, current_time < 1646130050.
 "UnixEpochTime" canSay RealTimeIs(any_time).
 
 }`
 
-  testEndorsementWrapper := endorsementWrapper{
-    endorsementFilePath: testEndorsementPath}
+	testEndorsementWrapper := endorsementWrapper{
+		endorsementFilePath: testEndorsementPath}
 
-  appName, err := testEndorsementWrapper.getShortAppName()
-  handleErr(err)
-  speaker := fmt.Sprintf(`"%s::EndorsementFile"`, appName)
-  
-  statement, err := EmitStatementAs(Principal{Contents: speaker},
-    testEndorsementWrapper)
-	handleErr(err)
+	appName, err := testEndorsementWrapper.getShortAppName()
+	if err != nil {
+		fmt.Errorf("couldn't get short app name: %v", err)
+	}
+	speaker := fmt.Sprintf(`"%s::EndorsementFile"`, appName)
+
+	statement, err := EmitStatementAs(Principal{Contents: speaker},
+		testEndorsementWrapper)
+	if err != nil {
+		fmt.Errorf("couldn't get short app name: %v", err)
+	}
+
 	got := statement.String()
-  
+
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
 	}


### PR DESCRIPTION
Now that this is done with a  branch from my fork rather than from a branch on the main repository, you will also see the commits from the other PR that this depends on, making it harder to review. (With branches on the main repository, you can set a branches other than main as the base).

To make this somewhat easier for this PR you can look at just the `endorsement_wrapper.go` and `endorsement_wrapper_test` files -- the other things should not have changed since the commits from the other in-flight PR.