### PR TITLE
Generate provenance files

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -21,6 +21,6 @@ package(default_visibility = ["//:__subpackages__"])
 go_library(
     name = "build",
     srcs = ["build.go"],
-    deps = ["//common:common"],
+    deps = ["//common:common", "//slsa:slsa"],
     importpath = "github.com/project-oak/transparent-release/build",
 )

--- a/build/build.go
+++ b/build/build.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/project-oak/transparent-release/common"
+	"github.com/project-oak/transparent-release/slsa"
 )
 
 // Build automates the steps for building a binary from a Git repository, and
@@ -35,43 +36,45 @@ import (
 // `expected_binary_sha256_hash`. If these hashes are not equal this function
 // returns an error. Otherwise, it generates a SLSA provenance file based on
 // the given build config.
-func Build(buildFilePath, gitRootDir string) error {
+func Build(buildFilePath, gitRootDir string) (*slsa.Provenance, error) {
 
 	buildConfig, err := common.LoadBuildConfigFromFile(buildFilePath)
 	if err != nil {
-		return fmt.Errorf("couldn't load build file %q: %v", buildFilePath, err)
+		return nil, fmt.Errorf("couldn't load build file %q: %v", buildFilePath, err)
 	}
 
 	if gitRootDir != "" {
 		if err := os.Chdir(gitRootDir); err != nil {
-			return fmt.Errorf("couldn't change directory to %s: %v", gitRootDir, err)
+			return nil, fmt.Errorf("couldn't change directory to %s: %v", gitRootDir, err)
 		}
 	} else {
 		// Fetch sources from the repo.
 		log.Printf("No gitRootDir specified. Fetching sources from %s.", buildConfig.Repo)
 		repoInfo, err := common.FetchSourcesFromRepo(buildConfig.Repo, buildConfig.CommitHash)
 		if err != nil {
-			return fmt.Errorf("couldn't fetch sources from %s: %v", buildConfig.Repo, err)
+			return nil, fmt.Errorf("couldn't fetch sources from %s: %v", buildConfig.Repo, err)
 		}
 		log.Printf("Fetched the repo into %q. See %q for any error logs.", repoInfo.RepoRoot, repoInfo.Logs)
 	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("couldn't get current working directory: %v", err)
+		return nil, fmt.Errorf("couldn't get current working directory: %v", err)
 	}
 	log.Printf("Building the binary in %q.", cwd)
 
 	if err := buildConfig.VerifyCommit(); err != nil {
-		return fmt.Errorf("Git commit hashes do not match: %v", err)
+		return nil, fmt.Errorf("Git commit hashes do not match: %v", err)
 	}
 
 	if err := buildConfig.Build(); err != nil {
-		return fmt.Errorf("couldn't build the binary: %v", err)
+		return nil, fmt.Errorf("couldn't build the binary: %v", err)
 	}
 
-	if err := buildConfig.GenerateProvenanceFile(); err != nil {
-		return fmt.Errorf("failed to generate the provenance file: %v", err)
+	prov, err := buildConfig.GenerateProvenanceStatement()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate the provenance file: %v", err)
 	}
-	return nil
+
+	return prov, nil
 }

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -16,8 +16,10 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"log"
+	"os"
 
 	"github.com/project-oak/transparent-release/build"
 )
@@ -27,9 +29,23 @@ func main() {
 		"Required - Path to a toml file containing the build configs.")
 	gitRootDirPtr := flag.String("git_root_dir", "",
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
+	provenancePathPtr := flag.String("provenance_path", "",
+		"Required - Output file name for storing the generated provenance file.")
+
 	flag.Parse()
 
-	if err := build.Build(*buildConfigPathPtr, *gitRootDirPtr); err != nil {
-		log.Fatalf("error when building the binary: %v", err)
+	prov, err := build.Build(*buildConfigPathPtr, *gitRootDirPtr)
+	if err != nil {
+		log.Fatalf("Couldn't build the binary: %v", err)
+	}
+
+	// Write the provenance statement to file.
+	bytes, err := json.Marshal(prov)
+	if err != nil {
+		log.Fatalf("Couldn't marshal the provenance: %v", err)
+	}
+
+	if err := os.WriteFile(*provenancePathPtr, bytes, 0644); err != nil {
+		log.Fatalf("Couldn't write provenance file: %v", err)
 	}
 }

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -25,16 +25,16 @@ import (
 )
 
 func main() {
-	buildConfigPathPtr := flag.String("config", "",
+	buildConfigPath := flag.String("build_config_path", "",
 		"Required - Path to a toml file containing the build configs.")
-	gitRootDirPtr := flag.String("git_root_dir", "",
+	gitRootDir := flag.String("git_root_dir", "",
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
-	provenancePathPtr := flag.String("provenance_path", "",
+	provenancePath := flag.String("provenance_path", "",
 		"Required - Output file name for storing the generated provenance file.")
 
 	flag.Parse()
 
-	prov, err := build.Build(*buildConfigPathPtr, *gitRootDirPtr)
+	prov, err := build.Build(*buildConfigPath, *gitRootDir)
 	if err != nil {
 		log.Fatalf("Couldn't build the binary: %v", err)
 	}
@@ -45,7 +45,7 @@ func main() {
 		log.Fatalf("Couldn't marshal the provenance: %v", err)
 	}
 
-	if err := os.WriteFile(*provenancePathPtr, bytes, 0644); err != nil {
+	if err := os.WriteFile(*provenancePath, bytes, 0644); err != nil {
 		log.Fatalf("Couldn't write provenance file: %v", err)
 	}
 }

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package main contains a command-line tool for verifying Amber provenance files.
+// Package main contains a command-line tool for building banaries and
+// generating SLSA provenance files, with Amber buildType.
 package main
 
 import (
@@ -28,7 +29,7 @@ func main() {
 	buildConfigPath := flag.String("build_config_path", "",
 		"Required - Path to a toml file containing the build configs.")
 	gitRootDir := flag.String("git_root_dir", "",
-		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
+		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the toml file.")
 	provenancePath := flag.String("provenance_path", "",
 		"Required - Output file name for storing the generated provenance file.")
 

--- a/common/common.go
+++ b/common/common.go
@@ -255,7 +255,7 @@ func (b *BuildConfig) VerifyBinarySha256Hash() error {
 }
 
 // GenerateProvenanceStatement generates a provenance statement from this config. If
-// `ExpectedBinarySha256Hash` is non-empty, the provenance statement is generated  only if the
+// `ExpectedBinarySha256Hash` is non-empty, the provenance statement is generated only if the
 // SHA256 hash of the generated binary is equal to `ExpectedBinarySha256Hash`.
 func (b *BuildConfig) GenerateProvenanceStatement() (*slsa.Provenance, error) {
 	binarySha256Hash, err := b.ComputeBinarySha256Hash()
@@ -271,7 +271,7 @@ func (b *BuildConfig) GenerateProvenanceStatement() (*slsa.Provenance, error) {
 	}
 
 	subject := slsa.Subject{
-		// TODO: Get the name as an input in the TOML file.
+		// TODO(#57): Get the name as an input in the TOML file.
 		Name:   fmt.Sprintf("%s-%s", filepath.Base(b.OutputPath), b.CommitHash),
 		Digest: map[string]string{"sha256": string(binarySha256Hash)},
 	}

--- a/common/common.go
+++ b/common/common.go
@@ -311,14 +311,14 @@ func (b *BuildConfig) GenerateProvenanceStatement() (*slsa.Provenance, error) {
 
 func parseBuilderImageURI(imageURI string) (string, string, error) {
 	// We expect the URI of the builder image to be of the form NAME@DIGEST
-	uRIParts := strings.Split(imageURI, "@")
-	if len(uRIParts) != 2 {
+	URIParts := strings.Split(imageURI, "@")
+	if len(URIParts) != 2 {
 		return "", "", fmt.Errorf("the builder image URI (%q) does not have the required NAME@DIGEST format", imageURI)
 	}
 	// We expect the DIGEST to be of the form ALG:VALUE
-	digestParts := strings.Split(uRIParts[1], ":")
+	digestParts := strings.Split(URIParts[1], ":")
 	if len(digestParts) != 2 {
-		return "", "", fmt.Errorf("the builder image digest (%q) does not have the required ALG:VALUE format", uRIParts[1])
+		return "", "", fmt.Errorf("the builder image digest (%q) does not have the required ALG:VALUE format", URIParts[1])
 	}
 
 	return digestParts[0], digestParts[1], nil

--- a/common/common.go
+++ b/common/common.go
@@ -25,10 +25,21 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	toml "github.com/pelletier/go-toml"
 	"github.com/project-oak/transparent-release/slsa"
+)
+
+const (
+	// InTotoStatementV01 is the statement type for the generalized link format
+	// containing statements. This is constant for all predicate types.
+	InTotoStatementV01 = "https://in-toto.io/Statement/v0.1"
+	// SLSAPredicateV02 is the predicate type for the SLSA v0.2 Provenance predicate type.
+	SLSAPredicateV02 = "https://slsa.dev/provenance/v0.2"
+	// AmberBuildTypeV1 is the SLSA BuildType for Amber builds.
+	AmberBuildTypeV1 = "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json"
 )
 
 // BuildConfig is a struct wrapping arguments for building a binary from source.
@@ -243,26 +254,74 @@ func (b *BuildConfig) VerifyBinarySha256Hash() error {
 	return nil
 }
 
-// GenerateProvenanceFile generates the provenance file. If
-// `ExpectedBinarySha256Hash` is non-empty, the provenance file is generated
-// only if the SHA256 hash of the generated binary is equal to
-// `ExpectedBinarySha256Hash`.
-func (b *BuildConfig) GenerateProvenanceFile() error {
-	// TODO(b/210658815): Instead of only checking the hash, generate the provenance file.
-
+// GenerateProvenanceStatement generates a provenance statement from this config. If
+// `ExpectedBinarySha256Hash` is non-empty, the provenance statement is generated  only if the
+// SHA256 hash of the generated binary is equal to `ExpectedBinarySha256Hash`.
+func (b *BuildConfig) GenerateProvenanceStatement() (*slsa.Provenance, error) {
 	binarySha256Hash, err := b.ComputeBinarySha256Hash()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	log.Printf("The hash of the binary is: %s", binarySha256Hash)
 
 	if b.ExpectedBinarySha256Hash != "" && b.ExpectedBinarySha256Hash != binarySha256Hash {
-		return fmt.Errorf("the hash of the output binary does not match the expected binary hash; got %s, want %v",
+		return nil, fmt.Errorf("the hash of the output binary does not match the expected binary hash; got %s, want %v",
 			binarySha256Hash, b.ExpectedBinarySha256Hash)
 	}
 
-	return nil
+	subject := slsa.Subject{
+		// TODO: Get the name as an input in the TOML file.
+		Name:   fmt.Sprintf("%s-%s", filepath.Base(b.OutputPath), b.CommitHash),
+		Digest: map[string]string{"sha256": string(binarySha256Hash)},
+	}
+
+	alg, digest, err := parseBuilderImageURI(b.BuilderImage)
+	if err != nil {
+		return nil, fmt.Errorf("malformed builder image URI: %v", err)
+	}
+
+	predicate := slsa.Predicate{
+		BuildType: AmberBuildTypeV1,
+		BuildConfig: slsa.BuildConfig{
+			Command:    b.Command,
+			OutputPath: b.OutputPath,
+		},
+		Materials: []slsa.Material{
+			// Builder image
+			slsa.Material{
+				URI:    b.BuilderImage,
+				Digest: map[string]string{alg: digest},
+			},
+			// Source code
+			slsa.Material{
+				URI:    b.Repo,
+				Digest: map[string]string{"sha1": b.CommitHash},
+			},
+		},
+	}
+
+	return &slsa.Provenance{
+		Type:          InTotoStatementV01,
+		Subject:       []slsa.Subject{subject},
+		PredicateType: SLSAPredicateV02,
+		Predicate:     predicate,
+	}, nil
+}
+
+func parseBuilderImageURI(imageURI string) (string, string, error) {
+	// We expect the URI of the builder image to be of the form NAME@DIGEST
+	uRIParts := strings.Split(imageURI, "@")
+	if len(uRIParts) != 2 {
+		return "", "", fmt.Errorf("the builder image URI (%q) does not have the required NAME@DIGEST format", imageURI)
+	}
+	// We expect the DIGEST to be of the form ALG:VALUE
+	digestParts := strings.Split(uRIParts[1], ":")
+	if len(digestParts) != 2 {
+		return "", "", fmt.Errorf("the builder image digest (%q) does not have the required ALG:VALUE format", uRIParts[1])
+	}
+
+	return digestParts[0], digestParts[1], nil
 }
 
 // saveToTempFile creates a tempfile in `/tmp` and writes the content of the

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -67,6 +67,23 @@ func TestLoadBuildConfigFromProvenance(t *testing.T) {
 	checkBuildConfig(config, t)
 }
 
+func TestParseBuilderImageURI(t *testing.T) {
+	imageURI := "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320"
+	alg, digest, err := parseBuilderImageURI(imageURI)
+	if err != nil {
+		t.Fatalf("couldn't parse imageURI (%q): %v", imageURI, err)
+	}
+
+	if alg != "sha256" {
+		t.Errorf("got parseBuilderImageURI(%s).algorithm = %s, want sha256", imageURI, alg)
+	}
+
+	want := "53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320"
+	if digest != want {
+		t.Errorf("got parseBuilderImageURI(%s).digest = %s, want %s", imageURI, alg, want)
+	}
+}
+
 func checkBuildConfig(got *BuildConfig, t *testing.T) {
 
 	want := &BuildConfig{

--- a/slsa/slsa_test.go
+++ b/slsa/slsa_test.go
@@ -32,9 +32,9 @@ func TestSlsaExampleProvenance(t *testing.T) {
 		t.Fatalf("Failed to parse example provenance: %v", err)
 	}
 
-	assert := func(name, want, got string) {
+	assert := func(name, got, want string) {
 		if want != got {
-			t.Fatalf("Unexpected %v want %s got %g", name, want, got)
+			t.Errorf("Unexpected %v: got %s, want %g", name, got, want)
 		}
 	}
 


### PR DESCRIPTION
Updates the `build` command line tool to generate provenance files if the build is successful. 