### PR TITLE
Fix linting 

### DIFF
--- a/experimental/auth-logic/top_level.go
+++ b/experimental/auth-logic/top_level.go
@@ -10,7 +10,8 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the Licen
+// limitations under the License.
+
 package main
 
 import (

--- a/scripts/linting.sh
+++ b/scripts/linting.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-lint_errors=$(golint ./...)
+lint_errors=$(golint ./... 2>&1)
 
 if [[ -z "$lint_errors" ]]; then
     echo No linting errors


### PR DESCRIPTION
Currently the linting does not fail is `golint` fails with error in stderr. This PR updates the linting script to fail in such cases too.