### PR TITLE
Refactor verify

### DIFF
--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -29,7 +29,11 @@ func main() {
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
 	flag.Parse()
 
-	if err := verify.Verify(*buildConfigPathPtr, *gitRootDirPtr); err != nil {
-		log.Fatalf("error when verifyfing the provenance: %v", err)
+	verifier := verify.ReproducibleProvenanceVerifier{
+		GitRootDir: *gitRootDirPtr,
+	}
+
+	if err := verifier.Verify(*buildConfigPathPtr); err != nil {
+		log.Fatalf("error when verifying the provenance: %v", err)
 	}
 }

--- a/experimental/auth-logic/wrappers/provenance_build_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_build_wrapper.go
@@ -41,7 +41,8 @@ func (pbw ProvenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	}
 
 	sanitizedAppName := SanitizeName(provenance.Subject[0].Name)
-	if err := verify.Verify(pbw.ProvenanceFilePath, ""); err != nil {
+	verifier := verify.ReproducibleProvenanceVerifier{}
+	if err := verifier.Verify(pbw.ProvenanceFilePath); err != nil {
 		return UnattributedStatement{}, fmt.Errorf("verification of the provenance file failed: %v", err)
 	}
 	measuredBinaryHash := provenance.Subject[0].Digest["sha256"]

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -28,6 +28,7 @@ import (
 // verifying provenances.
 type ProvenanceVerifier interface {
 	// Verify verifies an Amber/SLSA provenance file in the given path.
+	// Returns an error if the verification fails, or nil if it is successful.
 	Verify(path string) error
 }
 
@@ -41,7 +42,8 @@ type ReproducibleProvenanceVerifier struct {
 
 // Verify verifies a given SLSA provenance file by running the build script in
 // it and verifying that the resulting binary has a hash equal to the one
-// specified in the subject of the given provenance file.
+// specified in the subject of the given provenance file. If the hashes are
+// different returns an error, otherwise returns nil.
 func (verifier *ReproducibleProvenanceVerifier) Verify(provenanceFilePath string) error {
 	provenance, err := slsa.ParseProvenanceFile(provenanceFilePath)
 	if err != nil {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -24,8 +24,25 @@ import (
 	"github.com/project-oak/transparent-release/slsa"
 )
 
-// Verify verifies a given SLSA provenance file.
-func Verify(provenanceFilePath, gitRootDir string) error {
+// ProvenanceVerifier defines an interface with a single method `Verify` for
+// verifying provenances.
+type ProvenanceVerifier interface {
+	// Verify verifies an Amber/SLSA provenance file in the given path.
+	Verify(path string) error
+}
+
+// ReproducibleProvenanceVerifier is a verifier for verifying provenances that
+// are reproducible. The provenance is verified by building the binary as
+// specified in the provenance and checking that the hash of the binary is the
+// same as the digest in the subject of the provenance file.
+type ReproducibleProvenanceVerifier struct {
+	GitRootDir string
+}
+
+// Verify verifies a given SLSA provenance file by running the build script in
+// it and verifying that the resulting binary has a hash equal to the one
+// specified in the subject of the given provenance file.
+func (verifier *ReproducibleProvenanceVerifier) Verify(provenanceFilePath string) error {
 	provenance, err := slsa.ParseProvenanceFile(provenanceFilePath)
 	if err != nil {
 		return fmt.Errorf("couldn't load the provenance file from %s: %v", provenanceFilePath, err)
@@ -36,6 +53,7 @@ func Verify(provenanceFilePath, gitRootDir string) error {
 	}
 
 	// Change to git_root_dir if it is provided, otherwise, clone the repo.
+	gitRootDir := verifier.GitRootDir
 	if gitRootDir != "" {
 		if err := os.Chdir(gitRootDir); err != nil {
 			return fmt.Errorf("couldn't change directory to %s: %v", gitRootDir, err)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -25,9 +25,10 @@ func TestVerifyProvenanceFile(t *testing.T) {
 	// In the case of running tests bazel exposes data dependencies not in the
 	// current dir, but in the parent. Hence we need to move one level up.
 	os.Chdir("../")
-	path := schemaExamplePath
 
-	if err := Verify(path, ""); err != nil {
+	verifier := ReproducibleProvenanceVerifier{}
+
+	if err := verifier.Verify(schemaExamplePath); err != nil {
 		t.Fatalf("couldn't verify the provenance file: %v", err)
 	}
 }


### PR DESCRIPTION
Refactor verify to be able to more easily support different types of provenance verification logic.