### PR TITLE
Add skeleton for a metadata verifier

### DIFF
--- a/experimental/auth-logic/wrappers/provenance_build_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_build_wrapper.go
@@ -41,7 +41,8 @@ func (pbw ProvenanceBuildWrapper) EmitStatement() (UnattributedStatement, error)
 	}
 
 	sanitizedAppName := SanitizeName(provenance.Subject[0].Name)
-	verifier := verify.ReproducibleProvenanceVerifier{}
+	// TODO(#69): Set the verifier as a field in pbw, and use that here.
+	verifier := verify.AmberProvenanceMetadataVerifier{}
 	if err := verifier.Verify(pbw.ProvenanceFilePath); err != nil {
 		return UnattributedStatement{}, fmt.Errorf("verification of the provenance file failed: %v", err)
 	}

--- a/slsa/slsa_test.go
+++ b/slsa/slsa_test.go
@@ -22,8 +22,13 @@ import (
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
 
 func TestSlsaExampleProvenance(t *testing.T) {
-	// In the case of running tests bazel exposes data dependencies not in the
-	// current dir, but in the parent. Hence we need to move one level up.
+	// The path to provenance is specified relative to the root of the repo, so we need to go one level up.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
 	os.Chdir("../")
 
 	// Parses the provenance and validates it against the schema.

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -94,6 +94,7 @@ type AmberProvenanceMetadataVerifier struct {
 // against the expected values specified in this
 // AmberProvenanceMetadataVerifier instance. Returns an error if any of the
 // values is not as expected. Otherwise returns nil, indicating success.
+// TODO(#69): Check metadata against the expected values.
 func (verifier *AmberProvenanceMetadataVerifier) Verify(provenanceFilePath string) error {
 	provenance, err := slsa.ParseProvenanceFile(provenanceFilePath)
 	if err != nil {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -83,3 +83,28 @@ func (verifier *ReproducibleProvenanceVerifier) Verify(provenanceFilePath string
 
 	return nil
 }
+
+// AmberProvenanceMetadataVerifier verifies Amber provenances by comparing the
+// content of the provenance predicate against a given set of expected values.
+type AmberProvenanceMetadataVerifier struct {
+	// TODO(#69): Add metadata fields.
+}
+
+// Verify verifies a given Amber provenance file by checking its content
+// against the expected values specified in this
+// AmberProvenanceMetadataVerifier instance. Returns an error if any of the
+// values is not as expected. Otherwise returns nil, indicating success.
+func (verifier *AmberProvenanceMetadataVerifier) Verify(provenanceFilePath string) error {
+	provenance, err := slsa.ParseProvenanceFile(provenanceFilePath)
+	if err != nil {
+		return fmt.Errorf("couldn't load the provenance file from %s: %v", provenanceFilePath, err)
+	}
+
+	if provenance.Predicate.BuildType != common.AmberBuildTypeV1 {
+		return fmt.Errorf("incorrect BuildType: got %s, want %v", provenance.Predicate.BuildType, common.AmberBuildTypeV1)
+	}
+
+	// TODO(#69): Check metadata against the expected values.
+
+	return nil
+}

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -21,12 +21,32 @@ import (
 
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
 
-func TestVerifyProvenanceFile(t *testing.T) {
-	// In the case of running tests bazel exposes data dependencies not in the
-	// current dir, but in the parent. Hence we need to move one level up.
+func TestReproducibleProvenanceVerifier(t *testing.T) {
+	// The path to provenance is specified relative to the root of the repo, so we need to go one level up.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
 	os.Chdir("../")
-
 	verifier := ReproducibleProvenanceVerifier{}
+
+	if err := verifier.Verify(schemaExamplePath); err != nil {
+		t.Fatalf("couldn't verify the provenance file: %v", err)
+	}
+}
+
+func TestAmberProvenanceMetadataVerifier(t *testing.T) {
+	// The path to provenance is specified relative to the root of the repo, so we need to go one level up.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
+	os.Chdir("../")
+	verifier := AmberProvenanceMetadataVerifier{}
 
 	if err := verifier.Verify(schemaExamplePath); err != nil {
 		t.Fatalf("couldn't verify the provenance file: %v", err)


### PR DESCRIPTION
This is PR adds the skeleton for a metadata verifier for Amber provenances (`AmberProvenanceMetadataVerifier`) and calls it in `ProvenanceBuildWrapper`. This does not give a complete implementation for a metadata verifier, and is mainly intended to solve the problem of slow builds.

I have added a few TODO to identify the remaining work. In particular, we have to decide which fields need to be verified in the metadata verifier. The expected values should then be provided as input both to the `verify` command line tool, and to `ProvenanceBuildWrapper`, as well as the choice of the verifier (see #69). 