### PR TITLE
Check the output policy into the repository as an example

### DIFF
--- a/experimental/auth-logic/client-verification/examples/README.md
+++ b/experimental/auth-logic/client-verification/examples/README.md
@@ -1,0 +1,11 @@
+This directory contains an example output policy from the transparent release
+verification binary that has the values from the wrappers filled in. 
+This output example is in the file oak_verification_passing.auth_logic.
+
+This example was created by running the following from the root directory of the
+transparent release repository:
+```
+bazel build //experimental/auth-logic/client-verification:oak_verification_passing
+cp bazel-bin/experimental/auth-logic/client-verification/oak_verification_passing.auth_logic \
+    experimental/auth-logic/client-verification/oak_verification_passing.auth_logic
+```

--- a/experimental/auth-logic/client-verification/examples/oak_verification_passing.auth_logic
+++ b/experimental/auth-logic/client-verification/examples/oak_verification_passing.auth_logic
@@ -1,0 +1,65 @@
+.decl attribute has_expected_hash_from(hash : Sha256Hash, expecter : Principal)
+.decl attribute has_measured_hash(hash : Sha256Hash)
+.decl attribute hasProvenance(provenance : Principal)
+.decl RealTimeNsecIs(time : Number)
+
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Endorsement" says {
+    // The endorsement policy claims a binary has an expected hash if... 
+    "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c", "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Endorsement") :-
+        // ... the real time is less than the given expiry time and greater
+        // than the release time stated in the endorsement file.
+        RealTimeNsecIs(current_time), current_time >= 1643710850, current_time < 1961749250.
+
+    // The endorsement policy trusts a time measurement policy called
+    // "UnixEpoch" to get the current time. (This just uses the local clock)
+    "UnixEpochTime" canSay RealTimeNsecIs(any_time).
+
+}
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance" says {
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c", "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance").
+}
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::ProvenanceBuilder" says {
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" hasProvenance("oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance").
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_measured_hash("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c").
+
+}
+"UnixEpochTime" says {
+RealTimeNsecIs(1655899225).
+}
+"oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Verifier" says {
+    // The verification policy trusts the endorsement file wrapper to give
+    // the expected hash of the binary from the endorsement file.
+    "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Endorsement" canSay "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from(any_hash, "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Endorsement").
+    
+    // The verification policy trusts the provenance file wrapper to give the
+    // expected hash of the binary from the provenance file.
+    "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance" canSay "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from(any_hash, "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance").
+    
+    // The verification policy trusts the provenance file builder to 
+    // check when a binary can be successfully built from a provenance file.
+    "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::ProvenanceBuilder" canSay any_principal hasProvenance(any_provenance).
+    
+    // The verification policy trusts the provenance file builder to measure
+    // the real hashes of any object.
+    "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::ProvenanceBuilder" canSay some_object has_measured_hash(some_hash).
+    
+    // The verification policy trusts the rekor log checking policy (which 
+    // internally depends on the rekor log wrapper) to accurately 
+    // determine when an object is really a valid rekor log entry
+    "RekorLogCheck" canSay some_object canActAs "ValidRekorEntry".
+    
+    // The verification policy claims that a binary can assume the identity
+    // of an application when ...
+    "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" canActAs "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62" :-
+        // ... that binary can be built with some provenance file ...
+        "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" hasProvenance("oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance"),
+        // ... and an endorsement file and provenance file both give the same
+        // expected hash for the binary ...
+        "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from(binary_hash, "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Endorsement"),
+        "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_expected_hash_from(binary_hash, "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Provenance"),
+        // ... and the binary has the measured hash claimed by the endorsement/
+        /// provenance files.
+        "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" has_measured_hash(binary_hash).
+
+}
+oak_verification_passing = query "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Verifier" says "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62::Binary" canActAs "oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62"?


### PR DESCRIPTION
This is just the result of running `bazel build //experimental/auth-logic/client-verification:oak_verification_passing` 
and copying it into an examples directory. 

This output was probably easy to miss before. Now that you can clearly see the policy output of running this tool, this probably a good time to think about and comment on: 1) what strictly necessary things are missing from this, and 2) how this can be improved. Note that I am already aware that keys are in general missing from this and these will be added. Also note that some changes to this are already tracked [here](https://github.com/project-oak/transparent-release/issues/91)
