### PR TITLE
Add Builder.Id to provenance schema

### DIFF
--- a/experimental/auth-logic/client-verification/top_level.go
+++ b/experimental/auth-logic/client-verification/top_level.go
@@ -24,7 +24,8 @@ import (
 const relationDeclarations = ".decl attribute has_expected_hash_from(hash : Sha256Hash, expecter : Principal)\n" +
 	".decl attribute has_measured_hash(hash : Sha256Hash)\n" +
 	".decl attribute hasProvenance(provenance : Principal)\n" +
-	".decl RealTimeNsecIs(time : Number)\n"
+	".decl RealTimeNsecIs(time : Number)\n" +
+	".decl attribute has_builder_id(builder : URI)"
 
 // verifyRelease takes an application name, the path to an endorsement file
 // for that application, the path to a provenance file for that application,

--- a/experimental/auth-logic/test_data/oak_provenance.json
+++ b/experimental/auth-logic/test_data/oak_provenance.json
@@ -11,7 +11,7 @@
   "predicateType": "https://slsa.dev/provenance/v0.2",
   "predicate": {
     "builder": {
-      "id": "https://github.com/project-oak/transparent-release"
+      "id": "https://github.com/Attestations/GitHubHostedActions@v1"
     },
     "buildType": "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json",
     "buildConfig": {

--- a/experimental/auth-logic/test_data/oak_provenance.json
+++ b/experimental/auth-logic/test_data/oak_provenance.json
@@ -11,7 +11,7 @@
   "predicateType": "https://slsa.dev/provenance/v0.2",
   "predicate": {
     "builder": {
-      "id": "https://github.com/Attestations/GitHubHostedActions@v1"
+      "id": "https://github.com/project-oak/transparent-release"
     },
     "buildType": "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json",
     "buildConfig": {

--- a/experimental/auth-logic/wrappers/provenance_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper.go
@@ -49,10 +49,12 @@ func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 
 	return UnattributedStatement{
 		Contents: fmt.Sprintf(
-			`"%s::Binary" has_expected_hash_from("sha256:%s", "%s::Provenance").`,
+			`"%s::Binary" has_expected_hash_from("sha256:%s", "%s::Provenance").`+"\n"+`"%s::Binary" has_builder_id("%s").`,
 			sanitizedAppName,
 			expectedHash,
-			sanitizedAppName)}, nil
+			sanitizedAppName,
+			sanitizedAppName,
+			provenance.Predicate.Builder.Id)}, nil
 }
 
 // GetAppNameFromProvenance parses a provenance file and emits the name of the

--- a/experimental/auth-logic/wrappers/provenance_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper.go
@@ -47,6 +47,8 @@ func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 		return UnattributedStatement{}, fmt.Errorf("provenance file did not give an expected hash")
 	}
 
+	sanitizedBuilderName := SanitizeName(provenance.Predicate.Builder.Id)
+
 	return UnattributedStatement{
 		Contents: fmt.Sprintf(
 			`"%s::Binary" has_expected_hash_from("sha256:%s", "%s::Provenance").`+"\n"+`"%s::Binary" has_builder_id("%s").`,
@@ -54,7 +56,7 @@ func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 			expectedHash,
 			sanitizedAppName,
 			sanitizedAppName,
-			provenance.Predicate.Builder.Id)}, nil
+			sanitizedBuilderName)}, nil
 }
 
 // GetAppNameFromProvenance parses a provenance file and emits the name of the

--- a/experimental/auth-logic/wrappers/provenance_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper.go
@@ -47,7 +47,7 @@ func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 		return UnattributedStatement{}, fmt.Errorf("provenance file did not give an expected hash")
 	}
 
-	sanitizedBuilderName := SanitizeName(provenance.Predicate.Builder.Id)
+	sanitizedBuilderName := SanitizeName(provenance.Predicate.Builder.ID)
 
 	return UnattributedStatement{
 		Contents: fmt.Sprintf(

--- a/experimental/auth-logic/wrappers/provenance_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper_test.go
@@ -25,7 +25,7 @@ const provenanceExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
 func TestProvenanceWrapper(t *testing.T) {
 	want := `"oak_functions_loader::Provenance" says {
 "oak_functions_loader::Binary" has_expected_hash_from("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c", "oak_functions_loader::Provenance").
-"oak_functions_loader::Binary" has_builder_id("https://github.com/project-oak/transparent-release").
+"oak_functions_loader::Binary" has_builder_id("https://github.com/project:oak/transparent:release").
 }`
 
 	// When running tests, bazel exposes data dependencies relative to

--- a/experimental/auth-logic/wrappers/provenance_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper_test.go
@@ -25,6 +25,7 @@ const provenanceExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
 func TestProvenanceWrapper(t *testing.T) {
 	want := `"oak_functions_loader::Provenance" says {
 "oak_functions_loader::Binary" has_expected_hash_from("sha256:15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c", "oak_functions_loader::Provenance").
+"oak_functions_loader::Binary" has_builder_id("https://github.com/project-oak/transparent-release").
 }`
 
 	// When running tests, bazel exposes data dependencies relative to

--- a/slsa/slsa.go
+++ b/slsa/slsa.go
@@ -60,7 +60,7 @@ type Predicate struct {
 // The builder is the entity that produced the provenance file. Examples include
 // GitHub Actions and Google Cloud Build. See also [Salsa provenance files](https://slsa.dev/provenance/v0.2)
 type Builder struct {
-	Id string `json:"id"`
+	ID string `json:"id"`
 }
 
 // BuildConfig represents the BuildConfig in the SLSA buildType. See the corresponding

--- a/slsa/slsa.go
+++ b/slsa/slsa.go
@@ -50,9 +50,17 @@ type Digest map[string]string
 // Predicate represents the Predicate in the SLSA buildType. See the corresponding
 // JSON key in the Amber buildType schema.
 type Predicate struct {
+	Builder     Builder     `json:"builder"`
 	BuildType   string      `json:"buildType"`
 	BuildConfig BuildConfig `json:"buildConfig"`
 	Materials   []Material  `json:"materials"`
+}
+
+// Builder represents the builder ID in the SLSA schema for provenance files.
+// The builder is the entity that produced the provenance file. Examples include
+// GitHub Actions and Google Cloud Build. See also [Salsa provenance files](https://slsa.dev/provenance/v0.2)
+type Builder struct {
+	Id string `json:"id"`
 }
 
 // BuildConfig represents the BuildConfig in the SLSA buildType. See the corresponding

--- a/slsa/slsa_test.go
+++ b/slsa/slsa_test.go
@@ -53,4 +53,5 @@ func TestSlsaExampleProvenance(t *testing.T) {
 	assert("outputPath", provenance.Predicate.BuildConfig.OutputPath, "./oak_functions/loader/bin/oak_functions_loader")
 	assert("command[0]", provenance.Predicate.BuildConfig.Command[0], "./scripts/runner")
 	assert("command[1]", provenance.Predicate.BuildConfig.Command[1], "build-functions-server")
+	assert("builderId", provenance.Predicate.Builder.Id, "https://github.com/project-oak/transparent-release")
 }

--- a/slsa/slsa_test.go
+++ b/slsa/slsa_test.go
@@ -53,5 +53,5 @@ func TestSlsaExampleProvenance(t *testing.T) {
 	assert("outputPath", provenance.Predicate.BuildConfig.OutputPath, "./oak_functions/loader/bin/oak_functions_loader")
 	assert("command[0]", provenance.Predicate.BuildConfig.Command[0], "./scripts/runner")
 	assert("command[1]", provenance.Predicate.BuildConfig.Command[1], "build-functions-server")
-	assert("builderId", provenance.Predicate.Builder.Id, "https://github.com/project-oak/transparent-release")
+	assert("builderId", provenance.Predicate.Builder.ID, "https://github.com/project-oak/transparent-release")
 }


### PR DESCRIPTION
This also adds a statement about the builder ID to the provenance wrapper. It's likely that I'll adjust the statement produced by the provenance wrapper after #99 is merged.

This fixes #98 