### PR TITLE
Remove slsa.Provenance type

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 const testdataPath = "../testdata/"
-const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
+const provenanceExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
 
 func TestComputeBinarySha256Hash(t *testing.T) {
 	want := "56893dbba5667a305894b424c1fa58a0b51f994b117e62296fb6ee5986683856"
@@ -60,7 +60,7 @@ func TestLoadBuildConfigFromProvenance(t *testing.T) {
 	defer os.Chdir(currentDir)
 	os.Chdir("../")
 
-	provenance, err := amber.ParseProvenanceFile(schemaExamplePath)
+	provenance, err := amber.ParseProvenanceFile(provenanceExamplePath)
 	if err != nil {
 		t.Fatalf("couldn't parse the provenance file: %v", err)
 	}

--- a/experimental/auth-logic/wrappers/BUILD
+++ b/experimental/auth-logic/wrappers/BUILD
@@ -14,89 +14,90 @@
 # limitations under the License.
 #
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 package(default_visibility = ["//:__subpackages__"])
 
 go_library(
-  name = "wrapper_interface",
-  importpath = "github.com/project-oak/transparent-release/experimental/auth-logic/wrappers",
-  srcs = [
-    "wrappers.go",
-  ],
+    name = "wrapper_interface",
+    srcs = [
+        "wrappers.go",
+    ],
+    importpath = "github.com/project-oak/transparent-release/experimental/auth-logic/wrappers",
 )
 
 go_library(
-  name = "transparent_release_verification_wrappers",
-  importpath = "github.com/project-oak/transparent-release/experimental/auth-logic/wrappers",
-  srcs = [
-    "wrappers.go",
-    "endorsement_wrapper.go",
-    "provenance_build_wrapper.go",
-    "provenance_wrapper.go",
-    "rekor_wrapper.go",
-    "unix_epoch_time_wrapper.go",
-    "verifier_wrapper.go",
-  ],
-  data =[
-    "//experimental/auth-logic/templates:verifier_policy.auth.tmpl",
-    "//experimental/auth-logic/templates:endorsement_policy.auth.tmpl",
-    "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
-    "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl",
-  ],
-  deps = [
-    "//slsa:slsa", 
-    "//common:common", 
-    "//verify:verify",
-    "@com_github_sigstore_rekor//pkg/generated/models",
-    "@com_github_sigstore_rekor//pkg/types/rekord/v0.0.1:v0_0_1",
-    "@com_github_sigstore_rekor//pkg/types",
-    "@com_github_sigstore_sigstore//pkg/cryptoutils",
-    "@com_github_go_openapi_runtime//:go_default_library",
-    "@com_github_go_openapi_strfmt//:go_default_library",
-    "@com_github_cyberphone_json_canonicalization//go/src/webpki.org/jsoncanonicalizer"
-  ],
+    name = "transparent_release_verification_wrappers",
+    srcs = [
+        "endorsement_wrapper.go",
+        "provenance_build_wrapper.go",
+        "provenance_wrapper.go",
+        "rekor_wrapper.go",
+        "unix_epoch_time_wrapper.go",
+        "verifier_wrapper.go",
+        "wrappers.go",
+    ],
+    data = [
+        "//experimental/auth-logic/templates:endorsement_policy.auth.tmpl",
+        "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
+        "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl",
+        "//experimental/auth-logic/templates:verifier_policy.auth.tmpl",
+    ],
+    importpath = "github.com/project-oak/transparent-release/experimental/auth-logic/wrappers",
+    deps = [
+        "//common",
+        "//slsa",
+        "//verify",
+        "@com_github_cyberphone_json_canonicalization//go/src/webpki.org/jsoncanonicalizer",
+        "@com_github_go_openapi_runtime//:go_default_library",
+        "@com_github_go_openapi_strfmt//:go_default_library",
+        "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
+        "@com_github_sigstore_rekor//pkg/generated/models",
+        "@com_github_sigstore_rekor//pkg/types",
+        "@com_github_sigstore_rekor//pkg/types/rekord/v0.0.1:v0_0_1",
+        "@com_github_sigstore_sigstore//pkg/cryptoutils",
+    ],
 )
 
 go_test(
-  name = "wrapper_interface_test",
-  size = "small",
-  srcs = ["wrapper_interface_test.go"],
-  embed = [":wrapper_interface"],
+    name = "wrapper_interface_test",
+    size = "small",
+    srcs = ["wrapper_interface_test.go"],
+    embed = [":wrapper_interface"],
 )
 
 go_test(
-  name = "transparent_release_verification_wrappers_tests",
-  size = "small",
-  srcs = [
-    "unix_epoch_time_wrapper_test.go",
-    "provenance_wrapper_test.go",
-    "verifier_wrapper_test.go",
-    "endorsement_wrapper_test.go",
-    "rekor_wrapper_test.go",
-  ],
-  data = [
-    "//experimental/auth-logic/test_data:oak_ec_public.pem",
-    "//experimental/auth-logic/test_data:oak_endorsement.json",
-    "//experimental/auth-logic/test_data:rekor_entry.json",
-    "//experimental/auth-logic/test_data:rekor_public_key.pem",
-    "//experimental/auth-logic/test_data:verifier_wrapper_expected.auth_logic",
-    "//experimental/auth-logic/test_data:endorsement_wrapper_expected.auth_logic",
-    "//experimental/auth-logic/test_data:rekor_wrapper_expected.auth_logic",
-    "//schema/amber-slsa-buildtype/v1:provenance.json",
-    "//schema/amber-slsa-buildtype/v1:example.json",
-    "//schema/amber-endorsement/v1:example.json",
-  ],
-  embed = [":transparent_release_verification_wrappers"],
+    name = "transparent_release_verification_wrappers_tests",
+    size = "small",
+    srcs = [
+        "endorsement_wrapper_test.go",
+        "provenance_wrapper_test.go",
+        "rekor_wrapper_test.go",
+        "unix_epoch_time_wrapper_test.go",
+        "verifier_wrapper_test.go",
+    ],
+    data = [
+        "//experimental/auth-logic/test_data:endorsement_wrapper_expected.auth_logic",
+        "//experimental/auth-logic/test_data:oak_ec_public.pem",
+        "//experimental/auth-logic/test_data:oak_endorsement.json",
+        "//experimental/auth-logic/test_data:rekor_entry.json",
+        "//experimental/auth-logic/test_data:rekor_public_key.pem",
+        "//experimental/auth-logic/test_data:rekor_wrapper_expected.auth_logic",
+        "//experimental/auth-logic/test_data:verifier_wrapper_expected.auth_logic",
+        "//schema/amber-endorsement/v1:example.json",
+        "//schema/amber-slsa-buildtype/v1:example.json",
+        "//schema/amber-slsa-buildtype/v1:provenance.json",
+    ],
+    embed = [":transparent_release_verification_wrappers"],
 )
 
 go_test(
-  name = "provenance_build_wrapper_test",
-  size = "large",
-  srcs = ["provenance_build_wrapper_test.go"],
-  data = [
-      "//schema/amber-slsa-buildtype/v1:provenance.json",
-      "//schema/amber-slsa-buildtype/v1:example.json"
-  ],
-  embed = [":transparent_release_verification_wrappers"],
+    name = "provenance_build_wrapper_test",
+    size = "large",
+    srcs = ["provenance_build_wrapper_test.go"],
+    data = [
+        "//schema/amber-slsa-buildtype/v1:example.json",
+        "//schema/amber-slsa-buildtype/v1:provenance.json",
+    ],
+    embed = [":transparent_release_verification_wrappers"],
 )

--- a/experimental/auth-logic/wrappers/endorsement_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/endorsement_wrapper_test.go
@@ -26,6 +26,18 @@ const endorsementExpectedFile = "experimental/auth-logic/test_data/endorsement_w
 
 func TestEndorsementWrapper(t *testing.T) {
 
+	// When running tests, bazel exposes data dependencies relative to
+	// the directory structure of the WORKSPACE, so we need to change
+	// to the root directory of the transparent-release project to
+	// be able to read the resource files.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
+	os.Chdir("../../../")
+
 	wantFileBytes, err := os.ReadFile(endorsementExpectedFile)
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/experimental/auth-logic/wrappers/provenance_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper.go
@@ -20,7 +20,8 @@ package wrappers
 import (
 	"fmt"
 
-	"github.com/project-oak/transparent-release/slsa"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	amber "github.com/project-oak/transparent-release/slsa"
 )
 
 // ProvenanceWrapper is a wrapper that parses a provenance file
@@ -31,7 +32,7 @@ type ProvenanceWrapper struct{ FilePath string }
 // EmitStatement implements the wrapper interface for ProvenanceWrapper
 // by emitting the authorization logic statement.
 func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
-	provenance, err := slsa.ParseProvenanceFile(p.FilePath)
+	provenance, err := amber.ParseProvenanceFile(p.FilePath)
 	if err != nil {
 		return UnattributedStatement{}, fmt.Errorf("provenance wrapper couldn't prase provenance file: %v", err)
 	}
@@ -47,7 +48,8 @@ func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 		return UnattributedStatement{}, fmt.Errorf("provenance file did not give an expected hash")
 	}
 
-	sanitizedBuilderName := SanitizeName(provenance.Predicate.Builder.ID)
+	predicate := provenance.Predicate.(slsa.ProvenancePredicate)
+	sanitizedBuilderName := SanitizeName(predicate.Builder.ID)
 
 	return UnattributedStatement{
 		Contents: fmt.Sprintf(
@@ -63,7 +65,7 @@ func (p ProvenanceWrapper) EmitStatement() (UnattributedStatement, error) {
 // application it is about. This is useful for generating principal names,
 // for example.
 func GetAppNameFromProvenance(provenanceFilePath string) (string, error) {
-	provenance, provenanceErr := slsa.ParseProvenanceFile(provenanceFilePath)
+	provenance, provenanceErr := amber.ParseProvenanceFile(provenanceFilePath)
 	if provenanceErr != nil {
 		return "", provenanceErr
 	}

--- a/experimental/auth-logic/wrappers/provenance_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper_test.go
@@ -32,6 +32,12 @@ func TestProvenanceWrapper(t *testing.T) {
 	// the directory structure of the WORKSPACE, so we need to change
 	// to the root directory of the transparent-release project to
 	// be able to read the SLSA files.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
 	os.Chdir("../../../")
 
 	testProvenance := ProvenanceWrapper{FilePath: provenanceExamplePath}

--- a/experimental/auth-logic/wrappers/rekor_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/rekor_wrapper_test.go
@@ -28,6 +28,18 @@ const rekorPublicKeyPath = "experimental/auth-logic/test_data/rekor_public_key.p
 const rekorWrapperExpectedFile = "experimental/auth-logic/test_data/rekor_wrapper_expected.auth_logic"
 
 func TestRekorLogWrapper(t *testing.T) {
+	// When running tests, bazel exposes data dependencies relative to
+	// the directory structure of the WORKSPACE, so we need to change
+	// to the root directory of the transparent-release project to
+	// be able to read the resource files.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
+	os.Chdir("../../../")
+
 	rekorLogEntryBytes, err := ioutil.ReadFile(testRekorLogPath)
 	if err != nil {
 		t.Errorf("could not read rekor log file %v\n", testRekorLogPath)
@@ -83,6 +95,18 @@ func TestRekorLogWrapper(t *testing.T) {
 }
 
 func TestVerifySignedEntryTimestamp(t *testing.T) {
+	// When running tests, bazel exposes data dependencies relative to
+	// the directory structure of the WORKSPACE, so we need to change
+	// to the root directory of the transparent-release project to
+	// be able to read the resource files.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
+	os.Chdir("../../../")
+
 	rekorLogEntryBytes, err := ioutil.ReadFile(testRekorLogPath)
 	if err != nil {
 		t.Errorf("could not read rekor log file %v\n", testRekorLogPath)

--- a/experimental/auth-logic/wrappers/verifier_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/verifier_wrapper_test.go
@@ -28,6 +28,18 @@ func (v VerifierWrapper) identify() Principal {
 const testFilePath = "experimental/auth-logic/test_data/verifier_wrapper_expected.auth_logic"
 
 func TestVerifierWrapper(t *testing.T) {
+	// When running tests, bazel exposes data dependencies relative to
+	// the directory structure of the WORKSPACE, so we need to change
+	// to the root directory of the transparent-release project to
+	// be able to read the resource files.
+	// Get the current directory before that to restore the path at the end of the test.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldn't get current directory: %v", err)
+	}
+	defer os.Chdir(currentDir)
+	os.Chdir("../../../")
+
 	testWrapper := VerifierWrapper{AppName: "OakFunctionsLoader"}
 	statement, err := EmitStatementAs(testWrapper.identify(), testWrapper)
 	if err != nil {

--- a/slsa/BUILD
+++ b/slsa/BUILD
@@ -21,10 +21,14 @@ package(default_visibility = ["//:__subpackages__"])
 go_library(
     name = "slsa",
     srcs = ["slsa.go"],
-    importpath = "github.com/project-oak/transparent-release/slsa",
-    deps = ["@com_github_xeipuuv_gojsonschema//:go_default_library"],
     data = [
-        "//schema/amber-slsa-buildtype/v1:provenance.json"
+        "//schema/amber-slsa-buildtype/v1:provenance.json",
+    ],
+    importpath = "github.com/project-oak/transparent-release/slsa",
+    deps = [
+        "@com_github_in_toto_in_toto_golang//in_toto:go_default_library",
+        "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
+        "@com_github_xeipuuv_gojsonschema//:go_default_library",
     ],
 )
 
@@ -33,11 +37,12 @@ go_test(
     size = "small",
     srcs = ["slsa_test.go"],
     data = [
+        "//schema/amber-slsa-buildtype/v1:example.json",
         "//schema/amber-slsa-buildtype/v1:provenance.json",
-        "//schema/amber-slsa-buildtype/v1:example.json"
     ],
     embed = [":slsa"],
     deps = [
-        "@com_github_google_go_cmp//cmp:go_default_library"
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
     ],
 )

--- a/slsa/slsa.go
+++ b/slsa/slsa.go
@@ -82,7 +82,7 @@ func ParseProvenanceFile(path string) (*intoto.Statement, error) {
 	}
 
 	if err := json.Unmarshal(statementBytes, &statement); err != nil {
-		return nil, fmt.Errorf("could unmarshal the provenance file:\n%v", err)
+		return nil, fmt.Errorf("could not unmarshal the provenance file:\n%v", err)
 	}
 
 	// statement.Predicate is now just a map, we have to parse it into an instance of slsa.ProvenancePredicate
@@ -96,7 +96,7 @@ func ParseProvenanceFile(path string) (*intoto.Statement, error) {
 		return nil, fmt.Errorf("could not unmarshal JSON bytes into a slsa.ProvenancePredicate: %v", err)
 	}
 
-	// now predicate.BuildConfig is just a map, we have to parse it into an instance of BuildConfig
+	// Now predicate.BuildConfig is just a map, we have to parse it into an instance of BuildConfig
 	buildConfigBytes, err := json.Marshal(predicate.BuildConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal BuildConfig map into JSON bytes: %v", err)

--- a/slsa/slsa.go
+++ b/slsa/slsa.go
@@ -25,56 +25,16 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	intoto "github.com/in-toto/in-toto-golang/in_toto"
+	slsa2 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/xeipuuv/gojsonschema"
 )
-
-// Provenance represents an in-toto statement of the Amber SLSA buildType.
-type Provenance struct {
-	Type          string    `json:"_type"`
-	Subject       []Subject `json:"subject"`
-	PredicateType string    `json:"predicateType"`
-	Predicate     Predicate `json:"predicate"`
-}
-
-// Subject represents the Subject of the SLSA buildType. See the corresponding JSON
-// key in the Amber buildType schema.
-type Subject struct {
-	Name   string `json:"name"`
-	Digest Digest `json:"digest"`
-}
-
-// Digest represents a Digest in the SLSA buildType. See the corresponding JSON
-// key in the Amber buildType schema.
-type Digest map[string]string
-
-// Predicate represents the Predicate in the SLSA buildType. See the corresponding
-// JSON key in the Amber buildType schema.
-type Predicate struct {
-	Builder     Builder     `json:"builder"`
-	BuildType   string      `json:"buildType"`
-	BuildConfig BuildConfig `json:"buildConfig"`
-	Materials   []Material  `json:"materials"`
-}
-
-// Builder represents the builder ID in the SLSA schema for provenance files.
-// The builder is the entity that produced the provenance file. Examples include
-// GitHub Actions and Google Cloud Build. See also [Salsa provenance files](https://slsa.dev/provenance/v0.2)
-type Builder struct {
-	ID string `json:"id"`
-}
 
 // BuildConfig represents the BuildConfig in the SLSA buildType. See the corresponding
 // JSON key in the Amber buildType schema.
 type BuildConfig struct {
 	Command    []string `json:"command"`
 	OutputPath string   `json:"outputPath"`
-}
-
-// Material represents the Materials in the SLSA buildType. See the corresponding
-// JSON key in the Amber buildType schema.
-type Material struct {
-	URI    string `json:"uri"`
-	Digest Digest `json:"digest,omitempty"`
 }
 
 // SchemaPath is the path to Amber SLSA buildType schema
@@ -101,31 +61,55 @@ func validateJSON(provenanceFile []byte) error {
 			buffer.WriteString(err.String())
 		}
 
-		return fmt.Errorf("The provided provenance file is not valid. See errors:\n%v", buffer.String())
+		return fmt.Errorf("the provided provenance file is not valid. See errors:\n%v", buffer.String())
 	}
 
 	return nil
 }
 
 // ParseProvenanceFile reads a JSON file from a given path, validates it against the Amber
-// buildType schema, parses it into an instance of the Provenance struct.
-func ParseProvenanceFile(path string) (*Provenance, error) {
-	provenanceFile, readErr := ioutil.ReadFile(path)
+// buildType schema, and parses it into an instance of intoto.Statement.
+func ParseProvenanceFile(path string) (*intoto.Statement, error) {
+	statementBytes, readErr := ioutil.ReadFile(path)
 	if readErr != nil {
 		return nil, fmt.Errorf("could not read the provenance file: %v", readErr)
 	}
 
-	var provenance Provenance
+	var statement intoto.Statement
 
-	err := validateJSON(provenanceFile)
-	if err != nil {
+	if err := validateJSON(statementBytes); err != nil {
 		return nil, err
 	}
 
-	unmarshalErr := json.Unmarshal(provenanceFile, &provenance)
-	if unmarshalErr != nil {
-		return nil, fmt.Errorf("could unmarshal the provenance file:\n%v", unmarshalErr)
+	if err := json.Unmarshal(statementBytes, &statement); err != nil {
+		return nil, fmt.Errorf("could unmarshal the provenance file:\n%v", err)
 	}
 
-	return &provenance, nil
+	// statement.Predicate is now just a map, we have to parse it into an instance of slsa.ProvenancePredicate
+	predicateBytes, err := json.Marshal(statement.Predicate)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal Predicate map into JSON bytes: %v", err)
+	}
+
+	var predicate slsa2.ProvenancePredicate
+	if err = json.Unmarshal(predicateBytes, &predicate); err != nil {
+		return nil, fmt.Errorf("could not unmarshal JSON bytes into a slsa.ProvenancePredicate: %v", err)
+	}
+
+	// now predicate.BuildConfig is just a map, we have to parse it into an instance of BuildConfig
+	buildConfigBytes, err := json.Marshal(predicate.BuildConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal BuildConfig map into JSON bytes: %v", err)
+	}
+
+	var buildConfig BuildConfig
+	if err = json.Unmarshal(buildConfigBytes, &buildConfig); err != nil {
+		return nil, fmt.Errorf("could not unmarshal JSON bytes into a BuildConfig: %v", err)
+	}
+
+	// Replace maps with objects
+	predicate.BuildConfig = buildConfig
+	statement.Predicate = predicate
+
+	return &statement, nil
 }

--- a/slsa/slsa_test.go
+++ b/slsa/slsa_test.go
@@ -17,6 +17,8 @@ package slsa
 import (
 	"os"
 	"testing"
+
+	slsa2 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 )
 
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
@@ -43,15 +45,18 @@ func TestSlsaExampleProvenance(t *testing.T) {
 		}
 	}
 
+	predicate := provenance.Predicate.(slsa2.ProvenancePredicate)
+	buildConfig := predicate.BuildConfig.(BuildConfig)
+
 	// Check that the provenance parses correctly
-	assert("repoURL", provenance.Predicate.Materials[1].URI, "https://github.com/project-oak/oak")
-	assert("commitHash", provenance.Predicate.Materials[1].Digest["sha1"], "0f2189703c57845e09d8ab89164a4041c0af0a62")
-	assert("builderImage", provenance.Predicate.Materials[0].URI, "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320")
-	assert("commitHash", provenance.Predicate.Materials[0].Digest["sha256"], "53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320")
+	assert("repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
+	assert("commitHash", predicate.Materials[1].Digest["sha1"], "0f2189703c57845e09d8ab89164a4041c0af0a62")
+	assert("builderImage", predicate.Materials[0].URI, "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320")
+	assert("commitHash", predicate.Materials[0].Digest["sha256"], "53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320")
 	assert("subjectName", provenance.Subject[0].Name, "oak_functions_loader")
 	assert("expectedSha256Hash", provenance.Subject[0].Digest["sha256"], "15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c")
-	assert("outputPath", provenance.Predicate.BuildConfig.OutputPath, "./oak_functions/loader/bin/oak_functions_loader")
-	assert("command[0]", provenance.Predicate.BuildConfig.Command[0], "./scripts/runner")
-	assert("command[1]", provenance.Predicate.BuildConfig.Command[1], "build-functions-server")
-	assert("builderId", provenance.Predicate.Builder.ID, "https://github.com/project-oak/transparent-release")
+	assert("outputPath", buildConfig.OutputPath, "./oak_functions/loader/bin/oak_functions_loader")
+	assert("command[0]", buildConfig.Command[0], "./scripts/runner")
+	assert("command[1]", buildConfig.Command[1], "build-functions-server")
+	assert("builderId", predicate.Builder.ID, "https://github.com/project-oak/transparent-release")
 }

--- a/verify/BUILD
+++ b/verify/BUILD
@@ -21,11 +21,12 @@ package(default_visibility = ["//:__subpackages__"])
 go_library(
     name = "verify",
     srcs = ["verify.go"],
-    deps = [
-        "//common:common",
-        "//slsa:slsa",
-    ],
     importpath = "github.com/project-oak/transparent-release/verify",
+    deps = [
+        "//common",
+        "//slsa",
+        "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
+    ],
 )
 
 go_test(
@@ -33,8 +34,8 @@ go_test(
     size = "large",
     srcs = ["verify_test.go"],
     data = [
+        "//schema/amber-slsa-buildtype/v1:example.json",
         "//schema/amber-slsa-buildtype/v1:provenance.json",
-        "//schema/amber-slsa-buildtype/v1:example.json"
     ],
     embed = [":verify"],
 )

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -18,8 +18,9 @@ package verify
 import (
 	"fmt"
 
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/project-oak/transparent-release/common"
-	"github.com/project-oak/transparent-release/slsa"
+	amber "github.com/project-oak/transparent-release/slsa"
 )
 
 // ProvenanceVerifier defines an interface with a single method `Verify` for
@@ -43,7 +44,7 @@ type ReproducibleProvenanceVerifier struct {
 // specified in the subject of the given provenance file. If the hashes are
 // different returns an error, otherwise returns nil.
 func (verifier *ReproducibleProvenanceVerifier) Verify(provenanceFilePath string) error {
-	provenance, err := slsa.ParseProvenanceFile(provenanceFilePath)
+	provenance, err := amber.ParseProvenanceFile(provenanceFilePath)
 	if err != nil {
 		return fmt.Errorf("couldn't load the provenance file from %s: %v", provenanceFilePath, err)
 	}
@@ -85,13 +86,15 @@ type AmberProvenanceMetadataVerifier struct {
 // values is not as expected. Otherwise returns nil, indicating success.
 // TODO(#69): Check metadata against the expected values.
 func (verifier *AmberProvenanceMetadataVerifier) Verify(provenanceFilePath string) error {
-	provenance, err := slsa.ParseProvenanceFile(provenanceFilePath)
+	provenance, err := amber.ParseProvenanceFile(provenanceFilePath)
 	if err != nil {
 		return fmt.Errorf("couldn't load the provenance file from %s: %v", provenanceFilePath, err)
 	}
 
-	if provenance.Predicate.BuildType != common.AmberBuildTypeV1 {
-		return fmt.Errorf("incorrect BuildType: got %s, want %v", provenance.Predicate.BuildType, common.AmberBuildTypeV1)
+	predicate := provenance.Predicate.(slsa.ProvenancePredicate)
+
+	if predicate.BuildType != common.AmberBuildTypeV1 {
+		return fmt.Errorf("incorrect BuildType: got %s, want %v", predicate.BuildType, common.AmberBuildTypeV1)
 	}
 
 	// TODO(#69): Check metadata against the expected values.


### PR DESCRIPTION
Fixes #51 
Follow-up on #107

I ran `buildifier experimental/auth-logic/wrappers/BUILD`, which reordered the list of the test files in the BUILD file. This resulted in test failures because of incorrect paths. To fix this I had to add the same code for changing the directory in several tests. Not sure how all this repetition could be avoided. 

In a next PR, I will rename our package `slsa` to `amber` to have a more consistent naming. 