### PR TITLE
Rename the slsa package to amber

### DIFF
--- a/amber/BUILD
+++ b/amber/BUILD
@@ -19,12 +19,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 package(default_visibility = ["//:__subpackages__"])
 
 go_library(
-    name = "slsa",
-    srcs = ["slsa.go"],
+    name = "amber",
+    srcs = ["amber.go"],
     data = [
         "//schema/amber-slsa-buildtype/v1:provenance.json",
     ],
-    importpath = "github.com/project-oak/transparent-release/slsa",
+    importpath = "github.com/project-oak/transparent-release/amber",
     deps = [
         "@com_github_in_toto_in_toto_golang//in_toto:go_default_library",
         "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
@@ -33,14 +33,14 @@ go_library(
 )
 
 go_test(
-    name = "slsa_test",
+    name = "amber_test",
     size = "small",
-    srcs = ["slsa_test.go"],
+    srcs = ["amber_test.go"],
     data = [
         "//schema/amber-slsa-buildtype/v1:example.json",
         "//schema/amber-slsa-buildtype/v1:provenance.json",
     ],
-    embed = [":slsa"],
+    embed = [":amber"],
     deps = [
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",

--- a/amber/amber.go
+++ b/amber/amber.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package slsa provides functionality for parsing SLSA provenance files of the
+// Package amber provides functionality for parsing SLSA provenance files of the
 // Amber buildType.
 //
 // This package provides a utility function for loading and parsing a
 // JSON-formatted SLSA provenance file into an instance of Provenance.
-package slsa
+package amber
 
 import (
 	"bytes"
@@ -26,11 +26,11 @@ import (
 	"io/ioutil"
 
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
-	slsa2 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/xeipuuv/gojsonschema"
 )
 
-// BuildConfig represents the BuildConfig in the SLSA buildType. See the corresponding
+// BuildConfig represents the BuildConfig in the SLSA Provenance predicate. See the corresponding
 // JSON key in the Amber buildType schema.
 type BuildConfig struct {
 	Command    []string `json:"command"`
@@ -91,7 +91,7 @@ func ParseProvenanceFile(path string) (*intoto.Statement, error) {
 		return nil, fmt.Errorf("could not marshal Predicate map into JSON bytes: %v", err)
 	}
 
-	var predicate slsa2.ProvenancePredicate
+	var predicate slsa.ProvenancePredicate
 	if err = json.Unmarshal(predicateBytes, &predicate); err != nil {
 		return nil, fmt.Errorf("could not unmarshal JSON bytes into a slsa.ProvenancePredicate: %v", err)
 	}

--- a/amber/amber_test.go
+++ b/amber/amber_test.go
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package slsa
+package amber
 
 import (
 	"os"
 	"testing"
 
-	slsa2 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 )
 
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
 
-func TestSlsaExampleProvenance(t *testing.T) {
+func TestExampleProvenance(t *testing.T) {
 	// The path to provenance is specified relative to the root of the repo, so we need to go one level up.
 	// Get the current directory before that to restore the path at the end of the test.
 	currentDir, err := os.Getwd()
@@ -45,7 +45,7 @@ func TestSlsaExampleProvenance(t *testing.T) {
 		}
 	}
 
-	predicate := provenance.Predicate.(slsa2.ProvenancePredicate)
+	predicate := provenance.Predicate.(slsa.ProvenancePredicate)
 	buildConfig := predicate.BuildConfig.(BuildConfig)
 
 	// Check that the provenance parses correctly

--- a/build/BUILD
+++ b/build/BUILD
@@ -23,8 +23,8 @@ go_library(
     srcs = ["build.go"],
     importpath = "github.com/project-oak/transparent-release/build",
     deps = [
-        "//common",
         "//amber",
+        "//common",
         "@com_github_in_toto_in_toto_golang//in_toto:go_default_library",
     ],
 )

--- a/build/BUILD
+++ b/build/BUILD
@@ -24,7 +24,7 @@ go_library(
     importpath = "github.com/project-oak/transparent-release/build",
     deps = [
         "//common",
-        "//slsa",
+        "//amber",
         "@com_github_in_toto_in_toto_golang//in_toto:go_default_library",
     ],
 )

--- a/common/BUILD
+++ b/common/BUILD
@@ -23,7 +23,7 @@ go_library(
     srcs = ["common.go"],
     importpath = "github.com/project-oak/transparent-release/common",
     deps = [
-        "//slsa",
+        "//amber",
         "@com_github_in_toto_in_toto_golang//in_toto:go_default_library",
         "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
         "@com_github_pelletier_toml//:go_default_library",
@@ -41,7 +41,7 @@ go_test(
     ],
     embed = [":common"],
     deps = [
-        "//slsa",
+        "//amber",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/common/common.go
+++ b/common/common.go
@@ -32,7 +32,7 @@ import (
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	toml "github.com/pelletier/go-toml"
 
-	amber "github.com/project-oak/transparent-release/slsa"
+	"github.com/project-oak/transparent-release/amber"
 )
 
 const (

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -22,7 +22,7 @@ import (
 
 	cmp "github.com/google/go-cmp/cmp"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
-	amber "github.com/project-oak/transparent-release/slsa"
+	"github.com/project-oak/transparent-release/amber"
 )
 
 const testdataPath = "../testdata/"

--- a/experimental/auth-logic/client-verification/BUILD
+++ b/experimental/auth-logic/client-verification/BUILD
@@ -25,7 +25,7 @@ go_library(
     deps = [
         "//common",
         "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
-        "//slsa",
+        "//amber",
     ],
 )
 
@@ -43,7 +43,7 @@ go_binary(
   ],
   deps = [
     "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
-    "//slsa:slsa",
+    "//amber",
     "//common:common",
   ],
 )

--- a/experimental/auth-logic/client-verification/BUILD
+++ b/experimental/auth-logic/client-verification/BUILD
@@ -23,29 +23,29 @@ go_library(
     srcs = ["top_level.go"],
     importpath = "github.com/project-oak/transparent-release/experimental/auth-logic",
     deps = [
+        "//amber",
         "//common",
         "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
-        "//amber",
     ],
 )
 
 go_binary(
-  name = "auth_logic_verification",
-  srcs = [
-    "top_level.go",
-    "main.go",
-  ],
-  data = [
-    "//experimental/auth-logic/templates:verifier_policy.auth.tmpl",
-    "//experimental/auth-logic/templates:endorsement_policy.auth.tmpl",
-    "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
-    "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl"
-  ],
-  deps = [
-    "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
-    "//amber",
-    "//common:common",
-  ],
+    name = "auth_logic_verification",
+    srcs = [
+        "main.go",
+        "top_level.go",
+    ],
+    data = [
+        "//experimental/auth-logic/templates:endorsement_policy.auth.tmpl",
+        "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
+        "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl",
+        "//experimental/auth-logic/templates:verifier_policy.auth.tmpl",
+    ],
+    deps = [
+        "//amber",
+        "//common",
+        "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
+    ],
 )
 
 # This rule runs transparent release verification on the oak functions
@@ -65,7 +65,7 @@ genrule(
         "//experimental/auth-logic/templates:verifier_policy.auth.tmpl",
         "//experimental/auth-logic/templates:endorsement_policy.auth.tmpl",
         "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
-        "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl"
+        "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl",
     ],
     outs = [
         "oak_verification.auth_logic",
@@ -99,7 +99,7 @@ genrule(
         "//experimental/auth-logic/templates:verifier_policy.auth.tmpl",
         "//experimental/auth-logic/templates:endorsement_policy.auth.tmpl",
         "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
-        "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl"
+        "//experimental/auth-logic/templates:rekor_verifier_policy.auth.tmpl",
     ],
     outs = [
         "oak_verification_passing.auth_logic",

--- a/experimental/auth-logic/endorsement-release/BUILD
+++ b/experimental/auth-logic/endorsement-release/BUILD
@@ -19,40 +19,40 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 package(default_visibility = ["//:__subpackages__"])
 
 go_binary(
-  name = "endorsement_release_policy_generator",
-  srcs = [
-    "top_level.go",
-    "main.go",
-  ],
-  data = [
-    "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
-  ],
-  deps = [
-    "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
-    "//amber",
-    "//common:common",
-  ],
+    name = "endorsement_release_policy_generator",
+    srcs = [
+        "main.go",
+        "top_level.go",
+    ],
+    data = [
+        "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
+    ],
+    deps = [
+        "//amber",
+        "//common",
+        "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
+    ],
 )
 
 genrule(
-  name = "endorsement_release_oak_functions",
-  srcs = [
-    "//schema/amber-slsa-buildtype/v1:provenance.json",
-    "//experimental/auth-logic/test_data:oak_provenance.json",
-    "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
-    "//experimental/auth-logic/endorsement-release/input_policy_examples:github_actions_policy.auth_logic",
-    "//experimental/auth-logic/endorsement-release/input_policy_examples:oak_endorsement_policy.auth_logic",
-  ],
-  outs = [
-    "oak_endorsement_release_output_policy.auth_logic",
-  ],
-  cmd = """
+    name = "endorsement_release_oak_functions",
+    srcs = [
+        "//schema/amber-slsa-buildtype/v1:provenance.json",
+        "//experimental/auth-logic/test_data:oak_provenance.json",
+        "//experimental/auth-logic/templates:provenance_builder_policy.auth.tmpl",
+        "//experimental/auth-logic/endorsement-release/input_policy_examples:github_actions_policy.auth_logic",
+        "//experimental/auth-logic/endorsement-release/input_policy_examples:oak_endorsement_policy.auth_logic",
+    ],
+    outs = [
+        "oak_endorsement_release_output_policy.auth_logic",
+    ],
+    cmd = """
   export PROVENANCE=$(location //experimental/auth-logic/test_data:oak_provenance.json)
   export OAK_ENDORSEMENT_POLICY=$(location //experimental/auth-logic/endorsement-release/input_policy_examples:oak_endorsement_policy.auth_logic)
   export GITHUB_ACTIONS_POLICY=$(location //experimental/auth-logic/endorsement-release/input_policy_examples:github_actions_policy.auth_logic)
   ./$(location :endorsement_release_policy_generator) --app_name oak_functions_loader:0f2189703c57845e09d8ab89164a4041c0af0a62 --provenance $$PROVENANCE --auth_logic_inputs $$OAK_ENDORSEMENT_POLICY --auth_logic_inputs $$GITHUB_ACTIONS_POLICY --auth_logic_out $(RULEDIR)/oak_endorsement_release_output_policy.auth_logic
   """,
-  tools = [
-    ":endorsement_release_policy_generator",
-  ]
+    tools = [
+        ":endorsement_release_policy_generator",
+    ],
 )

--- a/experimental/auth-logic/endorsement-release/BUILD
+++ b/experimental/auth-logic/endorsement-release/BUILD
@@ -29,7 +29,7 @@ go_binary(
   ],
   deps = [
     "//experimental/auth-logic/wrappers:transparent_release_verification_wrappers",
-    "//slsa:slsa",
+    "//amber",
     "//common:common",
   ],
 )

--- a/experimental/auth-logic/wrappers/BUILD
+++ b/experimental/auth-logic/wrappers/BUILD
@@ -45,8 +45,8 @@ go_library(
     ],
     importpath = "github.com/project-oak/transparent-release/experimental/auth-logic/wrappers",
     deps = [
-        "//common",
         "//amber",
+        "//common",
         "//verify",
         "@com_github_cyberphone_json_canonicalization//go/src/webpki.org/jsoncanonicalizer",
         "@com_github_go_openapi_runtime//:go_default_library",

--- a/experimental/auth-logic/wrappers/BUILD
+++ b/experimental/auth-logic/wrappers/BUILD
@@ -46,7 +46,7 @@ go_library(
     importpath = "github.com/project-oak/transparent-release/experimental/auth-logic/wrappers",
     deps = [
         "//common",
-        "//slsa",
+        "//amber",
         "//verify",
         "@com_github_cyberphone_json_canonicalization//go/src/webpki.org/jsoncanonicalizer",
         "@com_github_go_openapi_runtime//:go_default_library",

--- a/experimental/auth-logic/wrappers/provenance_build_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_build_wrapper.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/project-oak/transparent-release/slsa"
+	"github.com/project-oak/transparent-release/amber"
 	"github.com/project-oak/transparent-release/verify"
 )
 
@@ -40,7 +40,7 @@ type simplifiedProvenance struct {
 // by emitting the authorization logic statement.
 func (pbw ProvenanceBuildWrapper) EmitStatement() (UnattributedStatement, error) {
 	// Unmarshal a provenance struct from the JSON file.
-	provenance, err := slsa.ParseProvenanceFile(pbw.ProvenanceFilePath)
+	provenance, err := amber.ParseProvenanceFile(pbw.ProvenanceFilePath)
 	if err != nil {
 		return UnattributedStatement{}, fmt.Errorf("provenance build wrapper couldn't parse provenance file: %v", err)
 	}

--- a/experimental/auth-logic/wrappers/provenance_wrapper.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
-	amber "github.com/project-oak/transparent-release/slsa"
+	"github.com/project-oak/transparent-release/amber"
 )
 
 // ProvenanceWrapper is a wrapper that parses a provenance file

--- a/verify/BUILD
+++ b/verify/BUILD
@@ -24,7 +24,7 @@ go_library(
     importpath = "github.com/project-oak/transparent-release/verify",
     deps = [
         "//common",
-        "//slsa",
+        "//amber",
         "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
     ],
 )

--- a/verify/BUILD
+++ b/verify/BUILD
@@ -23,8 +23,8 @@ go_library(
     srcs = ["verify.go"],
     importpath = "github.com/project-oak/transparent-release/verify",
     deps = [
-        "//common",
         "//amber",
+        "//common",
         "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
     ],
 )

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/project-oak/transparent-release/amber"
 	"github.com/project-oak/transparent-release/common"
-	amber "github.com/project-oak/transparent-release/slsa"
 )
 
 // ProvenanceVerifier defines an interface with a single method `Verify` for


### PR DESCRIPTION
Fixes #23

We use `amber` as the umbrella term to refer to our specialization of the in-toto and SLSA provenance standards (see [schemas](https://github.com/project-oak/transparent-release/tree/main/schema)). To be more consistent this PR updates the package name too. 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR