### PR TITLE
Remove endorsedForUse from Claim

### DIFF
--- a/pkg/amber/claim.go
+++ b/pkg/amber/claim.go
@@ -60,10 +60,6 @@ type ClaimIssuer struct {
 
 // ClaimMetadata contains metadata about the issued claims.
 type ClaimMetadata struct {
-	// EndorsedForUse specifies whether this claim endorses the artifact for
-	// use. Generally we expect this value to be true, but to allow for
-	// negative claims this field is included explicitly.
-	EndorsedForUse bool `json:"endorsedForUse"`
 	// IssuedOn specifies the timestamp (encoded as the Epoch time) when the
 	// claim was issued.
 	IssuedOn *time.Time `json:"issuedOn"`

--- a/schema/amber-claim/v1/example.json
+++ b/schema/amber-claim/v1/example.json
@@ -15,7 +15,6 @@
       },
       "claimType": "https://github.com/project-oak/transparent-release/endorsement/v2",
       "metadata": {
-        "endorsedForUse": true,
         "issuedOn": "2022-07-08T10:20:50.32Z",
         "expiresOn": "2022-08-08T10:20:50.32Z"
       },


### PR DESCRIPTION
It seems like `endorsedForUse` is not always required. If a field like this is required, it could be included as a field in `ClaimSpec`. In case of endorsements, we can assume that the presence of an unexpired endorsement implies `endorsedForUse = true`.

See also https://github.com/project-oak/transparent-release/pull/110#discussion_r918719754.