### PR TITLE
Update go-version and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ">=1.18"
+          go-version: "=1.18.4"
       - name: Run go fmt
         run: |
           ./scripts/formatting.sh
@@ -62,10 +62,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ">=1.18"
+          go-version: "=1.18.4"
       - name: Run golint
         run: |
-          sudo apt-get install -y golint
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2
           ./scripts/linting.sh
 
   vetting:
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ">=1.18"
+          go-version: "=1.18.4"
       - name: Run go vet
         run: |
           go vet ./...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5033,7 +5033,7 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17.2")
+go_register_toolchains(version = "1.18.4")
 
 gazelle_dependencies()
 

--- a/build/build.go
+++ b/build/build.go
@@ -37,7 +37,6 @@ import (
 // returns an error. Otherwise, it generates a SLSA provenance file based on
 // the given build config.
 func Build(buildFilePath, gitRootDir string) (*intoto.Statement, error) {
-
 	buildConfig, err := common.LoadBuildConfigFromFile(buildFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't load build file %q: %v", buildFilePath, err)

--- a/common/BUILD
+++ b/common/BUILD
@@ -42,6 +42,7 @@ go_test(
     embed = [":common"],
     deps = [
         "//pkg/amber",
+        "//internal/testutil",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/common/common.go
+++ b/common/common.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -346,7 +345,7 @@ func (b *BuildConfig) ChangeDirToGitRoot(gitRootDir string) (*RepoCheckoutInfo, 
 	}
 
 	if err := b.VerifyCommit(); err != nil {
-		return nil, fmt.Errorf("Git commit hashes do not match: %v", err)
+		return nil, fmt.Errorf("the Git commit hashes do not match: %v", err)
 	}
 
 	return info, nil
@@ -375,7 +374,7 @@ func saveToTempFile(reader io.Reader) (string, error) {
 		return "", err
 	}
 
-	tmpfile, err := ioutil.TempFile("", "log-*.txt")
+	tmpfile, err := os.CreateTemp("", "log-*.txt")
 	if err != nil {
 		return "", fmt.Errorf("couldn't create tempfile: %v", err)
 	}
@@ -393,7 +392,7 @@ func saveToTempFile(reader io.Reader) (string, error) {
 // containing the absolute path to the root of the repo is returned.
 func FetchSourcesFromRepo(repoURL, commitHash string) (*RepoCheckoutInfo, error) {
 	// create a temp folder in the current directory for fetching the repo.
-	targetDir, err := ioutil.TempDir("", "release-*")
+	targetDir, err := os.MkdirTemp("", "release-*")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create temp directory: %v", err)
 	}
@@ -444,14 +443,6 @@ func FetchSourcesFromRepo(repoURL, commitHash string) (*RepoCheckoutInfo, error)
 	}
 
 	return &info, nil
-}
-
-func toStringSlice(slice []interface{}) []string {
-	ss := make([]string, 0, len(slice))
-	for _, s := range slice {
-		ss = append(ss, s.(string))
-	}
-	return ss
 }
 
 func computeSha256Hash(path string) (string, error) {

--- a/common/common.go
+++ b/common/common.go
@@ -239,7 +239,6 @@ func (b *BuildConfig) ComputeBinarySha256Hash() (string, error) {
 	}
 
 	return binarySha256Hash, nil
-
 }
 
 // VerifyBinarySha256Hash computes the SHA256 hash of the binary built by this
@@ -278,7 +277,7 @@ func (b *BuildConfig) GenerateProvenanceStatement() (*intoto.Statement, error) {
 	subject := intoto.Subject{
 		// TODO(#57): Get the name as an input in the TOML file.
 		Name:   fmt.Sprintf("%s-%s", filepath.Base(b.OutputPath), b.CommitHash),
-		Digest: slsa.DigestSet{"sha256": string(binarySha256Hash)},
+		Digest: slsa.DigestSet{"sha256": binarySha256Hash},
 	}
 
 	alg, digest, err := parseBuilderImageURI(b.BuilderImage)
@@ -294,12 +293,12 @@ func (b *BuildConfig) GenerateProvenanceStatement() (*intoto.Statement, error) {
 		},
 		Materials: []slsa.ProvenanceMaterial{
 			// Builder image
-			slsa.ProvenanceMaterial{
+			{
 				URI:    b.BuilderImage,
 				Digest: slsa.DigestSet{alg: digest},
 			},
 			// Source code
-			slsa.ProvenanceMaterial{
+			{
 				URI:    b.Repo,
 				Digest: slsa.DigestSet{"sha1": b.CommitHash},
 			},

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -148,7 +148,6 @@ func TestGenerateProvenanceStatement(t *testing.T) {
 }
 
 func checkBuildConfig(got *BuildConfig, t *testing.T) {
-
 	want := &BuildConfig{
 		Repo:                     "https://github.com/project-oak/oak",
 		CommitHash:               "0f2189703c57845e09d8ab89164a4041c0af0a62",

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -22,6 +22,7 @@ import (
 
 	cmp "github.com/google/go-cmp/cmp"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/project-oak/transparent-release/internal/testutil"
 	"github.com/project-oak/transparent-release/pkg/amber"
 )
 
@@ -57,8 +58,8 @@ func TestLoadBuildConfigFromProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../")
 
 	provenance, err := amber.ParseProvenanceFile(provenanceExamplePath)
 	if err != nil {
@@ -72,7 +73,7 @@ func TestLoadBuildConfigFromProvenance(t *testing.T) {
 	checkBuildConfig(config, t)
 }
 
-func TestParseBuilderImageURI_ValidURI(t *testing.T) {
+func TestParseBuilderImageUriValidURI(t *testing.T) {
 	imageURI := "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320"
 	alg, digest, err := parseBuilderImageURI(imageURI)
 	if err != nil {
@@ -89,7 +90,7 @@ func TestParseBuilderImageURI_ValidURI(t *testing.T) {
 	}
 }
 
-func TestParseBuilderImageURI_InvalidURIs(t *testing.T) {
+func TestParseBuilderImageUriInvalidURIs(t *testing.T) {
 	imageURIWithTag := "gcr.io/oak-ci/oak@latest"
 	want := fmt.Sprintf("the builder image digest (%q) does not have the required ALG:VALUE format", "latest")
 	alg, digest, err := parseBuilderImageURI(imageURIWithTag)

--- a/experimental/auth-logic/client-verification/main.go
+++ b/experimental/auth-logic/client-verification/main.go
@@ -26,7 +26,6 @@ import (
 // process for the application using this evidence. The authorization logic
 // compiler can then run on the generated code.
 func main() {
-
 	appName := flag.String("app_name", "", "set name of application to be released")
 	endorsementFilePath := flag.String("endorsement", "", "set path of endorsement file")
 	provenanceFilePath := flag.String("provenance", "", "set path of provenance file")
@@ -54,5 +53,4 @@ func main() {
 	if err != nil {
 		log.Fatalf("Couldn't write generated authorization logic to file: %v\nThe generated auth logic was this:\n%s", err, out)
 	}
-
 }

--- a/experimental/auth-logic/client-verification/main.go
+++ b/experimental/auth-logic/client-verification/main.go
@@ -41,10 +41,15 @@ func main() {
 	}
 
 	file, err := os.Create(*outputFilePath)
-	defer file.Close()
 	if err != nil {
 		log.Fatalf("Couldn't create file for generated authorizaiton logic: %v\nThe generated auth logic was this:\n%s", err, out)
 	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Fatalf("Couldn't close the file: %v", err)
+		}
+	}()
+
 	_, err = file.WriteString(out)
 	if err != nil {
 		log.Fatalf("Couldn't write generated authorization logic to file: %v\nThe generated auth logic was this:\n%s", err, out)

--- a/experimental/auth-logic/client-verification/oak_auth_logic_verification_test.go
+++ b/experimental/auth-logic/client-verification/oak_auth_logic_verification_test.go
@@ -39,5 +39,4 @@ func TestOakVerification(t *testing.T) {
 			t.Fatalf("Query %q failed; want %t got %t.", query, want, got)
 		}
 	}
-
 }

--- a/experimental/auth-logic/client-verification/top_level.go
+++ b/experimental/auth-logic/client-verification/top_level.go
@@ -32,7 +32,6 @@ const relationDeclarations = ".decl attribute has_expected_hash_from(hash : Sha2
 // and emits authorization logic code (as a string) that runs the transparent
 // release verification process.
 func verifyRelease(appName, endorsementFilePath, provenanceFilePath, queryName string) (string, error) {
-
 	endorsementAppName, err := wrappers.GetAppNameFromEndorsement(endorsementFilePath)
 	if err != nil {
 		return "", fmt.Errorf("verifyRelease couldn't get name from endorsement file: %s, error: %v", endorsementFilePath, err)
@@ -111,5 +110,4 @@ func verifyRelease(appName, endorsementFilePath, provenanceFilePath, queryName s
 		verifierStatement.String(),
 		topLevelQuery,
 	}[:], "\n"), nil
-
 }

--- a/experimental/auth-logic/common/auth_logic_interface.go
+++ b/experimental/auth-logic/common/auth_logic_interface.go
@@ -15,7 +15,7 @@
 package common
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -35,20 +35,20 @@ import (
 // emitted.
 func EmitOutputQueries(outputDirectoryName string) (map[string]bool, error) {
 	ret := make(map[string]bool)
-	items, err := ioutil.ReadDir(outputDirectoryName)
+	items, err := os.ReadDir(outputDirectoryName)
 	if err != nil {
 		return nil, err
 	}
 	for _, item := range items {
 		filename := item.Name()
 		if strings.HasSuffix(filename, ".csv") {
-			contents, err := ioutil.ReadFile(filepath.Join(
+			contents, err := os.ReadFile(filepath.Join(
 				outputDirectoryName, filename))
 			if err != nil {
 				return nil, err
 			}
 			queryName := strings.ReplaceAll(filename, ".csv", "")
-			// Because the ouput CSVs either contain "dummy_var" if they
+			// Because the output CSVs either contain "dummy_var" if they
 			// can be proved or contain nothing if they cannot, the
 			// query is true if and only if the CSV has more than zero bytes
 			if len(contents) > 0 {

--- a/experimental/auth-logic/common/simple_auth_logic_test.go
+++ b/experimental/auth-logic/common/simple_auth_logic_test.go
@@ -42,5 +42,4 @@ func TestSimpleAuthLogic(t *testing.T) {
 	for query, expected := range expectedQueryValues {
 		assert(query, expected, actualQueryValues[query])
 	}
-
 }

--- a/experimental/auth-logic/endorsement-release/main.go
+++ b/experimental/auth-logic/endorsement-release/main.go
@@ -47,16 +47,21 @@ func main() {
 
 	flag.Parse()
 
-	out, err := verifyRelease(authLogicInputs, *appName, *provenanceFilePath)
+	out, err := verifyRelease(authLogicInputs, *provenanceFilePath)
 	if err != nil {
 		log.Fatalf("couldn't generate auth logic policy for endorsement file: %v", err)
 	}
 
 	file, err := os.Create(*outputAuthLogicFilePath)
-	defer file.Close()
 	if err != nil {
 		log.Fatalf("couldn't create file for generated authorizaiton logic: %v\nThe generated auth logic was this:\n%s", err, out)
 	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			log.Fatalf("couldn't close the file: %v", err)
+		}
+	}()
+
 	_, err = file.WriteString(out)
 	if err != nil {
 		log.Fatalf("couldn't write generated authorization logic to file: %v\nThe generated auth logic was this:\n%s", err, out)

--- a/experimental/auth-logic/endorsement-release/main.go
+++ b/experimental/auth-logic/endorsement-release/main.go
@@ -37,7 +37,6 @@ func (someStringArray *stringArray) Set(value string) error {
 }
 
 func main() {
-
 	var authLogicInputs stringArray
 
 	appName := flag.String("app_name", "", "name of application to be released")
@@ -66,5 +65,4 @@ func main() {
 	if err != nil {
 		log.Fatalf("couldn't write generated authorization logic to file: %v\nThe generated auth logic was this:\n%s", err, out)
 	}
-
 }

--- a/experimental/auth-logic/endorsement-release/release_verification_query_test.go
+++ b/experimental/auth-logic/endorsement-release/release_verification_query_test.go
@@ -30,5 +30,4 @@ func TestEndorsementReleaseVerification(t *testing.T) {
 	if want := true; want != got {
 		t.Errorf("Query releaseEndorsement failed; want %t got %t.", want, got)
 	}
-
 }

--- a/experimental/auth-logic/endorsement-release/top_level.go
+++ b/experimental/auth-logic/endorsement-release/top_level.go
@@ -35,7 +35,6 @@ const relationDeclarations = ".decl BuildPolicyAllowRelease(binary : Principal, 
 // logic code that verifies the release (by concatenating the input files with
 // the outputs the necessary wrappers).
 func verifyRelease(authLogicInputs []string, provenanceFilePath string) (string, error) {
-
 	var authLogicFileContents = ""
 	for _, authLogicInputFile := range authLogicInputs {
 		fileContents, err := os.ReadFile(authLogicInputFile)
@@ -70,5 +69,4 @@ func verifyRelease(authLogicInputs []string, provenanceFilePath string) (string,
 		provenanceStatement.String(),
 		timeStatement.String(),
 	}[:], "\n"), nil
-
 }

--- a/experimental/auth-logic/endorsement-release/top_level.go
+++ b/experimental/auth-logic/endorsement-release/top_level.go
@@ -34,7 +34,7 @@ const relationDeclarations = ".decl BuildPolicyAllowRelease(binary : Principal, 
 // for verifying release and a path to a provenance file. It emits authorization
 // logic code that verifies the release (by concatenating the input files with
 // the outputs the necessary wrappers).
-func verifyRelease(authLogicInputs []string, appName, provenanceFilePath string) (string, error) {
+func verifyRelease(authLogicInputs []string, provenanceFilePath string) (string, error) {
 
 	var authLogicFileContents = ""
 	for _, authLogicInputFile := range authLogicInputs {

--- a/experimental/auth-logic/wrappers/BUILD
+++ b/experimental/auth-logic/wrappers/BUILD
@@ -89,6 +89,7 @@ go_test(
         "//schema/amber-slsa-buildtype/v1:provenance.json",
     ],
     embed = [":transparent_release_verification_wrappers"],
+    deps = ["//internal/testutil"],
 )
 
 go_test(
@@ -100,4 +101,5 @@ go_test(
         "//schema/amber-slsa-buildtype/v1:provenance.json",
     ],
     embed = [":transparent_release_verification_wrappers"],
+    deps = ["//internal/testutil"],
 )

--- a/experimental/auth-logic/wrappers/endorsement_wrapper.go
+++ b/experimental/auth-logic/wrappers/endorsement_wrapper.go
@@ -95,7 +95,6 @@ func ParseEndorsementBytes(endorsementBytes []byte) (*Endorsement, error) {
 // GenerateValidatedEndorsement produces a ValidatedEndorsement from an
 // Endorsement
 func (endorsement Endorsement) GenerateValidatedEndorsement() (ValidatedEndorsement, error) {
-
 	if len(endorsement.Subject) != 1 {
 		return ValidatedEndorsement{},
 			fmt.Errorf("endorsement file missing subject: %s", endorsement)
@@ -134,7 +133,6 @@ func (endorsement Endorsement) GenerateValidatedEndorsement() (ValidatedEndorsem
 		ReleaseTime: releaseTime,
 		ExpiryTime:  expiryTime,
 	}, nil
-
 }
 
 // EndorsementWrapper is a wrapper that emits an authorization logic

--- a/experimental/auth-logic/wrappers/endorsement_wrapper.go
+++ b/experimental/auth-logic/wrappers/endorsement_wrapper.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"text/template"
 	"time"
 )
@@ -71,7 +71,7 @@ type ValidatedEndorsement struct {
 // ParseEndorsementFile parses an endorsement file (in JSON) and
 // produces an `Endorsement` data structure.
 func ParseEndorsementFile(path string) (*Endorsement, error) {
-	endorsementBytes, err := ioutil.ReadFile(path)
+	endorsementBytes, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not read the endorsement file: %v", err)
 	}

--- a/experimental/auth-logic/wrappers/endorsement_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/endorsement_wrapper_test.go
@@ -27,7 +27,6 @@ const testEndorsementPath = "schema/amber-endorsement/v1/example.json"
 const endorsementExpectedFile = "experimental/auth-logic/test_data/endorsement_wrapper_expected.auth_logic"
 
 func TestEndorsementWrapper(t *testing.T) {
-
 	// When running tests, bazel exposes data dependencies relative to
 	// the directory structure of the WORKSPACE, so we need to change
 	// to the root directory of the transparent-release project to
@@ -64,5 +63,4 @@ func TestEndorsementWrapper(t *testing.T) {
 	if got := statement.String(); got != want {
 		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
 	}
-
 }

--- a/experimental/auth-logic/wrappers/endorsement_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/endorsement_wrapper_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 const testEndorsementPath = "schema/amber-endorsement/v1/example.json"
@@ -35,8 +37,8 @@ func TestEndorsementWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../../../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../../../")
 
 	wantFileBytes, err := os.ReadFile(endorsementExpectedFile)
 	if err != nil {
@@ -59,9 +61,7 @@ func TestEndorsementWrapper(t *testing.T) {
 		t.Fatalf("couldn't get endorsement file statement : %v", err)
 	}
 
-	got := statement.String()
-
-	if got != want {
+	if got := statement.String(); got != want {
 		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
 	}
 

--- a/experimental/auth-logic/wrappers/provenance_build_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/provenance_build_wrapper_test.go
@@ -16,8 +16,9 @@ package wrappers
 
 import (
 	"fmt"
-	"os"
 	"testing"
+
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
@@ -33,7 +34,7 @@ func TestProvenanceBuildWrapper(t *testing.T) {
 	// the directory structure of the WORKSPACE, so we need to change
 	// to the root directory of the transparent-release project to
 	// be able to read the SLSA files.
-	os.Chdir("../../../")
+	testutil.Chdir(t, "../../../")
 
 	appName, err := GetAppNameFromProvenance(schemaExamplePath)
 	if err != nil {
@@ -46,9 +47,8 @@ func TestProvenanceBuildWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get statement from provenance file: %s, error:%v", schemaExamplePath, err)
 	}
-	got := statement.String()
 
-	if got != want {
+	if got := statement.String(); got != want {
 		t.Errorf("got:\n%v\nwant:\n%v\n", got, want)
 	}
 }

--- a/experimental/auth-logic/wrappers/provenance_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper_test.go
@@ -53,5 +53,4 @@ func TestProvenanceWrapper(t *testing.T) {
 	if got := statement.String(); got != want {
 		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
 	}
-
 }

--- a/experimental/auth-logic/wrappers/provenance_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/provenance_wrapper_test.go
@@ -15,9 +15,10 @@
 package wrappers
 
 import (
-	"fmt"
 	"os"
 	"testing"
+
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 const provenanceExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
@@ -37,20 +38,19 @@ func TestProvenanceWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../../../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../../../")
 
 	testProvenance := ProvenanceWrapper{FilePath: provenanceExamplePath}
 
-	speaker := Principal{Contents: fmt.Sprintf(`"Provenance"`)}
+	speaker := Principal{Contents: `"Provenance"`}
 
 	statement, err := EmitStatementAs(speaker, testProvenance)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	got := statement.String()
 
-	if got != want {
+	if got := statement.String(); got != want {
 		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
 	}
 

--- a/experimental/auth-logic/wrappers/rekor_wrapper.go
+++ b/experimental/auth-logic/wrappers/rekor_wrapper.go
@@ -26,7 +26,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"text/template"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
@@ -54,9 +54,9 @@ type RekorLogWrapper struct {
 
 const rekorVerifierTemplate = "experimental/auth-logic/templates/rekor_verifier_policy.auth.tmpl"
 
-func getLogEntryAnonFromFile(rekorLogFilePath string) (*models.LogEntryAnon, error) {
+func GetLogEntryAnonFromFile(rekorLogFilePath string) (*models.LogEntryAnon, error) {
 	// get LogEntry, which is a map from strings to LogEntryAnons
-	logEntryBytes, err := ioutil.ReadFile(rekorLogFilePath)
+	logEntryBytes, err := os.ReadFile(rekorLogFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read the rekor log file: %v", err)
 	}
@@ -247,7 +247,7 @@ func compareEndorsementAndRekorHash(rekorEntry *rekord.V001Entry, endorsementByt
 
 	endorsementHash := fmt.Sprintf("%x", sha256.Sum256(endorsementBytes))
 	if endorsementHash != *rekorEntry.RekordObj.Data.Hash.Value {
-		return fmt.Errorf("Hash values of endorsement bytes and rekor entry not equal. endorsementHash: %s, rekorHash: %v",
+		return fmt.Errorf("hash values of endorsement bytes and rekor entry not equal. endorsementHash: %s, rekorHash: %v",
 			endorsementHash, *rekorEntry.RekordObj.Data.Hash.Value)
 	}
 	return nil

--- a/experimental/auth-logic/wrappers/rekor_wrapper.go
+++ b/experimental/auth-logic/wrappers/rekor_wrapper.go
@@ -159,7 +159,7 @@ func pubKeyBytesToECDSA(keyData []byte) (*ecdsa.PublicKey, error) {
 // LogEntryAnon.Verification, but only if it is non-empty. If it is empty
 // it will not error, so this function just throws an error if the verification
 // is empty
-func checkInclusionProof(logEntryAnon *models.LogEntryAnon, registry strfmt.Registry) error {
+func checkInclusionProof(logEntryAnon *models.LogEntryAnon) error {
 	if logEntryAnon.Verification == nil {
 		return fmt.Errorf("logEntryAnon did not have inclusion proof")
 	}
@@ -279,7 +279,7 @@ func VerifyRekorEntry(rekorLogEntryBytes, productTeamKeyBytes, rekorPublicKeyByt
 	}
 
 	// Verify inclusion proof
-	err = checkInclusionProof(logEntryAnon, strfmt.Default)
+	err = checkInclusionProof(logEntryAnon)
 	if err != nil {
 		return fmt.Errorf("couldn't validate logEntryAnon (which includes inclusion proof checking):%v ", err)
 	}
@@ -340,5 +340,4 @@ func (rlw RekorLogWrapper) EmitStatement() (UnattributedStatement, error) {
 	}
 
 	return UnattributedStatement{Contents: policyBytes.String()}, nil
-
 }

--- a/experimental/auth-logic/wrappers/rekor_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/rekor_wrapper_test.go
@@ -92,7 +92,6 @@ func TestRekorLogWrapper(t *testing.T) {
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s\n", got, want)
 	}
-
 }
 
 func TestVerifySignedEntryTimestamp(t *testing.T) {
@@ -127,5 +126,4 @@ func TestVerifySignedEntryTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not verify signed entry timestamp: %v", err)
 	}
-
 }

--- a/experimental/auth-logic/wrappers/rekor_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/rekor_wrapper_test.go
@@ -15,10 +15,11 @@
 package wrappers
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 const testRekorLogPath = "experimental/auth-logic/test_data/rekor_entry.json"
@@ -37,25 +38,25 @@ func TestRekorLogWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../../../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../../../")
 
-	rekorLogEntryBytes, err := ioutil.ReadFile(testRekorLogPath)
+	rekorLogEntryBytes, err := os.ReadFile(testRekorLogPath)
 	if err != nil {
 		t.Errorf("could not read rekor log file %v\n", testRekorLogPath)
 	}
 
-	prodTeamKeyBytes, err := ioutil.ReadFile(testPubKeyPath)
+	prodTeamKeyBytes, err := os.ReadFile(testPubKeyPath)
 	if err != nil {
 		t.Errorf("could not parse prod team pub key from file: %s", testPubKeyPath)
 	}
 
-	endorsementBytes, err := ioutil.ReadFile(testUnexpiredEndorsementFilePath)
+	endorsementBytes, err := os.ReadFile(testUnexpiredEndorsementFilePath)
 	if err != nil {
 		t.Errorf("could not read endorsement file: %s, %v", testUnexpiredEndorsementFilePath, err)
 	}
 
-	rekorKeyBytes, err := ioutil.ReadFile(rekorPublicKeyPath)
+	rekorKeyBytes, err := os.ReadFile(rekorPublicKeyPath)
 	if err != nil {
 		t.Errorf("could not parse rekord pub key from file: %s", rekorKeyBytes)
 	}
@@ -104,15 +105,15 @@ func TestVerifySignedEntryTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../../../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../../../")
 
-	rekorLogEntryBytes, err := ioutil.ReadFile(testRekorLogPath)
+	rekorLogEntryBytes, err := os.ReadFile(testRekorLogPath)
 	if err != nil {
 		t.Errorf("could not read rekor log file %v\n", testRekorLogPath)
 	}
 
-	rekorKeyBytes, err := ioutil.ReadFile(rekorPublicKeyPath)
+	rekorKeyBytes, err := os.ReadFile(rekorPublicKeyPath)
 	if err != nil {
 		t.Errorf("could not parse rekor pub key from file: %s", rekorKeyBytes)
 	}

--- a/experimental/auth-logic/wrappers/unix_epoch_time_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/unix_epoch_time_wrapper_test.go
@@ -27,7 +27,7 @@ const (
 	futureDate = 33197947200
 )
 
-func (time UnixEpochTime) identify() Principal {
+func (timeWrapper UnixEpochTime) identify() Principal {
 	return Principal{Contents: "UnixEpochTime"}
 }
 
@@ -57,5 +57,4 @@ func TestUnixEpochTimeWrapper(t *testing.T) {
 	if timeValue > futureDate {
 		t.Errorf("The emitted current time %v, is far into the future", timeValue)
 	}
-
 }

--- a/experimental/auth-logic/wrappers/verifier_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/verifier_wrapper_test.go
@@ -57,5 +57,4 @@ func TestVerifierWrapper(t *testing.T) {
 	if got := statement.String(); got != want {
 		t.Errorf("got:\n%v\nwant:\n%v", got, want)
 	}
-
 }

--- a/experimental/auth-logic/wrappers/verifier_wrapper_test.go
+++ b/experimental/auth-logic/wrappers/verifier_wrapper_test.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 func (v VerifierWrapper) identify() Principal {
@@ -37,15 +39,14 @@ func TestVerifierWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../../../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../../../")
 
 	testWrapper := VerifierWrapper{AppName: "OakFunctionsLoader"}
 	statement, err := EmitStatementAs(testWrapper.identify(), testWrapper)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	got := statement.String()
 
 	wantFileBytes, err := os.ReadFile(testFilePath)
 	if err != nil {
@@ -53,7 +54,7 @@ func TestVerifierWrapper(t *testing.T) {
 	}
 	want := strings.TrimSuffix(string(wantFileBytes), "\n")
 
-	if got != want {
+	if got := statement.String(); got != want {
 		t.Errorf("got:\n%v\nwant:\n%v", got, want)
 	}
 

--- a/experimental/auth-logic/wrappers/wrapper_interface_test.go
+++ b/experimental/auth-logic/wrappers/wrapper_interface_test.go
@@ -16,7 +16,7 @@ package wrappers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -47,13 +47,12 @@ func TestEmitWrapperStatement(t *testing.T) {
 	}
 
 	want := "Summer says {\nsum(2, 3, 5).\n}"
-	resultBytes, err := ioutil.ReadFile("wrapped_sum.auth_logic")
+	resultBytes, err := os.ReadFile("wrapped_sum.auth_logic")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 
-	got := string(resultBytes)
-	if got != want {
+	if got := string(resultBytes); got != want {
 		t.Fatalf("got %v want %v", got, want)
 	}
 }

--- a/golangci-linters.yaml
+++ b/golangci-linters.yaml
@@ -1,0 +1,226 @@
+linters:
+  # Disable all linters.
+  # Default: false
+  # disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - cyclop
+    - deadcode
+    - decorder
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    # - errorlint
+    - execinquery
+    - exhaustive
+    # - exhaustivestruct
+    - exhaustruct
+    - exportloopref
+    - forbidigo
+    # Might be nice to enable it later.
+    # - forcetypeassert
+    # - funlen
+    # - gci
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    # - gocritic
+    - gocyclo
+    # - godot
+    # TODO/BUG/FIXME: would be nice to enable it later.
+    # - godox
+    # Consider enabling it.
+    # - goerr113
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    # - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - grouper
+    - ifshort
+    - importas
+    - ineffassign
+    - interfacer
+    # - ireturn
+    # Line length: Would be nice to enable it later.
+    # - lll
+    - maintidx
+    - makezero
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    # - nlreturn
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosnakecase
+    - nosprintfhostport
+    # Might be nice to enable it later.
+    # - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - tagliatelle
+    - tenv
+    # - testpackage
+    # Consider enabling it later.
+    # - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - varnamelen
+    - wastedassign
+    - whitespace
+    # - wrapcheck
+    # - wsl
+  # Enable all available linters.
+  # Default: false
+  # enable-all: true
+  # Disable specific linter
+  # https://golangci-lint.run/usage/linters/#disabled-by-default-linters--e--enable
+  disable:
+    # - asasalint
+    # - asciicheck
+    # - bidichk
+    # - bodyclose
+    # - containedctx
+    # - contextcheck
+    # - cyclop
+    # - deadcode
+    # - decorder
+    # - depguard
+    # - dogsled
+    # - dupl
+    # - durationcheck
+    # - errcheck
+    # - errchkjson
+    # - errname
+    # - errorlint
+    # - execinquery
+    # - exhaustive
+    - exhaustivestruct
+    # - exhaustruct
+    # - exportloopref
+    # - forbidigo
+    - forcetypeassert
+    - funlen
+    - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - goconst
+    - gocritic
+    # - gocyclo
+    - godot
+    - godox
+    # - goerr113
+    # - gofmt
+    # - gofumpt
+    # - goheader
+    # - goimports
+    # - golint
+    - gomnd
+    # - gomoddirectives
+    # - gomodguard
+    # - goprintffuncname
+    # - gosec
+    # - gosimple
+    # - govet
+    # - grouper
+    # - ifshort
+    # - importas
+    # - ineffassign
+    # - interfacer
+    - ireturn
+    - lll
+    # - maintidx
+    # - makezero
+    # - maligned
+    # - misspell
+    # - nakedret
+    # - nestif
+    # - nilerr
+    # - nilnil
+    - nlreturn
+    # - noctx
+    # - nolintlint
+    # - nonamedreturns
+    # - nosnakecase
+    # - nosprintfhostport
+    - paralleltest
+    # - prealloc
+    # - predeclared
+    # - promlinter
+    # - revive
+    # - rowserrcheck
+    # - scopelint
+    # - sqlclosecheck
+    # - staticcheck
+    # - structcheck
+    # - stylecheck
+    # - tagliatelle
+    # - tenv
+    - testpackage
+    - thelper
+    # - tparallel
+    # - typecheck
+    # - unconvert
+    # - unparam
+    # - unused
+    # - varcheck
+    # - varnamelen
+    # - wastedassign
+    # - whitespace
+    - wrapcheck
+    - wsl
+  # Enable presets.
+  # https://golangci-lint.run/usage/linters
+  presets:
+    - bugs
+    - comment
+    - complexity
+    - error
+    - format
+    - import
+    - metalinter
+    - module
+    - performance
+    - sql
+    - style
+    - test
+    - unused
+  # Run only fast linters from enabled linters set (first run won't be fast)
+  # Default: false
+  fast: true

--- a/golangci-linters.yaml
+++ b/golangci-linters.yaml
@@ -25,7 +25,7 @@ linters:
     - execinquery
     - exhaustive
     # - exhaustivestruct
-    - exhaustruct
+    # - exhaustruct
     - exportloopref
     - forbidigo
     # Might be nice to enable it later.
@@ -44,7 +44,7 @@ linters:
     # Consider enabling it.
     # - goerr113
     - gofmt
-    - gofumpt
+    # - gofumpt
     - goheader
     - goimports
     - golint
@@ -52,7 +52,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
-    - gosec
+    # - gosec
     - gosimple
     - govet
     - grouper
@@ -89,7 +89,7 @@ linters:
     - staticcheck
     - structcheck
     - stylecheck
-    - tagliatelle
+    # - tagliatelle
     - tenv
     # - testpackage
     # Consider enabling it later.
@@ -131,7 +131,7 @@ linters:
     # - execinquery
     # - exhaustive
     - exhaustivestruct
-    # - exhaustruct
+    - exhaustruct
     # - exportloopref
     # - forbidigo
     - forcetypeassert
@@ -147,7 +147,7 @@ linters:
     - godox
     # - goerr113
     # - gofmt
-    # - gofumpt
+    - gofumpt
     # - goheader
     # - goimports
     # - golint
@@ -155,7 +155,7 @@ linters:
     # - gomoddirectives
     # - gomodguard
     # - goprintffuncname
-    # - gosec
+    - gosec
     # - gosimple
     # - govet
     # - grouper
@@ -190,7 +190,7 @@ linters:
     # - staticcheck
     # - structcheck
     # - stylecheck
-    # - tagliatelle
+    - tagliatelle
     # - tenv
     - testpackage
     - thelper

--- a/internal/testutil/BUILD
+++ b/internal/testutil/BUILD
@@ -14,29 +14,12 @@
 # limitations under the License.
 #
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 package(default_visibility = ["//:__subpackages__"])
 
 go_library(
-    name = "verify",
-    srcs = ["verify.go"],
-    importpath = "github.com/project-oak/transparent-release/verify",
-    deps = [
-        "//pkg/amber",
-        "//common",
-        "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
-    ],
-)
-
-go_test(
-    name = "verify_test",
-    size = "large",
-    srcs = ["verify_test.go"],
-    data = [
-        "//schema/amber-slsa-buildtype/v1:example.json",
-        "//schema/amber-slsa-buildtype/v1:provenance.json",
-    ],
-    embed = [":verify"],
-    deps = ["//internal/testutil"],
+    name = "testutil",
+    srcs = ["util.go"],
+    importpath = "github.com/project-oak/transparent-release/internal/testutil",
 )

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -12,23 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package testutil
 
 import (
+	"os"
 	"testing"
-
-	"github.com/project-oak/transparent-release/experimental/auth-logic/common"
 )
 
-func TestEndorsementReleaseVerification(t *testing.T) {
-	actualQueryValues, err := common.EmitOutputQueries(".")
-	if actualQueryValues == nil || err != nil {
-		t.Fatalf("Could not parse verification query results for oak_functions_loader: %v", err)
+func Chdir(t *testing.T, dir string) {
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("couldn't change directory to %s: %v", dir, err)
 	}
-
-	got := actualQueryValues["testEndorsementReleaseQuery"]
-	if want := true; want != got {
-		t.Errorf("Query releaseEndorsement failed; want %t got %t.", want, got)
-	}
-
 }

--- a/pkg/amber/BUILD
+++ b/pkg/amber/BUILD
@@ -47,6 +47,7 @@ go_test(
     ],
     embed = [":amber"],
     deps = [
+        "//internal/testutil",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_in_toto_in_toto_golang//in_toto/slsa_provenance/v0.2:go_default_library",
     ],

--- a/pkg/amber/claim.go
+++ b/pkg/amber/claim.go
@@ -41,7 +41,7 @@ type ClaimPredicate struct {
 	// The issuer of the claim.
 	Issuer ClaimIssuer `json:"issuer"`
 	// URI indicating the type of the claim. It determines the meaning of
-	//`ClaimSpec` and `Evidence`.
+	// `ClaimSpec` and `Evidence`.
 	ClaimType string `json:"claimType"`
 	// An optional arbitrary object that gives a detailed description of the claim.
 	ClaimSpec interface{} `json:"claimSpec,omitempty"`

--- a/pkg/amber/endorsement_test.go
+++ b/pkg/amber/endorsement_test.go
@@ -44,5 +44,4 @@ func TestExampleAmberEndorsement(t *testing.T) {
 	if len(claimPredicate.Evidence) != 1 {
 		t.Errorf("Exactly one evidence is expected: got %d", len(claimPredicate.Evidence))
 	}
-
 }

--- a/pkg/amber/provenance_test.go
+++ b/pkg/amber/provenance_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
@@ -30,8 +31,8 @@ func TestExampleProvenance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../../")
 
 	// Parses the provenance and validates it against the schema.
 	provenance, err := ParseProvenanceFile(schemaExamplePath)

--- a/schema/amber-endorsement/v1/endorsement_test.go
+++ b/schema/amber-endorsement/v1/endorsement_test.go
@@ -18,7 +18,7 @@ package schema
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -54,8 +54,7 @@ func TestExampleAmberEndorsement(t *testing.T) {
 }
 
 func loadJSON(path string) (gojsonschema.JSONLoader, error) {
-
-	jsonFile, err := ioutil.ReadFile(path)
+	jsonFile, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read json file %v: %v", path, err)
 	}

--- a/scripts/linting.sh
+++ b/scripts/linting.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-lint_errors=$(golangci-lint run 2>&1)
+readonly PROJECT_ROOT_DIR="$(dirname $(dirname "$0"))"
+
+lint_errors=$(golangci-lint run --config "$PROJECT_ROOT_DIR/golangci-linters.yaml"  2>&1)
 
 if [[ -z "$lint_errors" ]]; then
     echo No linting errors

--- a/scripts/linting.sh
+++ b/scripts/linting.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-lint_errors=$(golint ./... 2>&1)
+lint_errors=$(golangci-lint run 2>&1)
 
 if [[ -z "$lint_errors" ]]; then
     echo No linting errors

--- a/scripts/linting.sh
+++ b/scripts/linting.sh
@@ -2,7 +2,7 @@
 
 readonly PROJECT_ROOT_DIR="$(dirname $(dirname "$0"))"
 
-lint_errors=$(golangci-lint run --config "$PROJECT_ROOT_DIR/golangci-linters.yaml"  2>&1)
+lint_errors=$(golangci-lint run --config "$PROJECT_ROOT_DIR/golangci-linters.yaml")
 
 if [[ -z "$lint_errors" ]]; then
     echo No linting errors

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -17,6 +17,8 @@ package verify
 import (
 	"os"
 	"testing"
+
+	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
 const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
@@ -28,8 +30,8 @@ func TestReproducibleProvenanceVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../")
 	verifier := ReproducibleProvenanceVerifier{}
 
 	if err := verifier.Verify(schemaExamplePath); err != nil {
@@ -44,8 +46,8 @@ func TestAmberProvenanceMetadataVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't get current directory: %v", err)
 	}
-	defer os.Chdir(currentDir)
-	os.Chdir("../")
+	defer testutil.Chdir(t, currentDir)
+	testutil.Chdir(t, "../")
 	verifier := AmberProvenanceMetadataVerifier{}
 
 	if err := verifier.Verify(schemaExamplePath); err != nil {


### PR DESCRIPTION
This is a spinoff of #111, which uses generics. 
To be able to use generics, I had to update go-version for the CI and in WORKSPACE to 1.18.4. But the generics notation is not supported by `golint`, and actually `golint` is deprecated. This PR replaces `golint` with `golangci-lint`, as a result several files had to be modified to conform to the new linting rules. The main changes are:
- Updated .github/workflows/ci.yml
- Updated scripts/linting.sh
- Added golangci-linters.yaml (list of enabled and disabled linters)
- Added internal/testutil/ (a small testing util)

The rest of the changes are linting and related to the use of `testutil`.