### PR TITLE
Make tests more stable

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//schema/amber-slsa-buildtype/v1:example.json",
         "//schema/amber-slsa-buildtype/v1:provenance.json",
         "//testdata:build.toml",
+        "//testdata:static.txt",
     ],
     embed = [":common"],
     deps = [

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -131,26 +131,14 @@ func TestGenerateProvenanceStatement(t *testing.T) {
 	buildConfig := predicate.BuildConfig.(amber.BuildConfig)
 
 	// Check that the provenance is generated correctly
-	assertEq(t, "repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
-	assertNonEmpty(t, "subjectName", prov.Subject[0].Name)
-	assertEq(t, "subjectDigest", len(prov.Subject[0].Digest["sha256"]), wantSHA256HexDigitLength)
-	assertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSHA1HexDigitLength)
-	assertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSHA256HexDigitLength)
-	assertEq(t, "builderImageURI", predicate.Materials[0].URI, fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", predicate.Materials[0].Digest["sha256"]))
-	assertNonEmpty(t, "command[0]", buildConfig.Command[0])
-	assertNonEmpty(t, "command[1]", buildConfig.Command[1])
-}
-
-func assertEq[T comparable](t *testing.T, name string, got, want T) {
-	if got != want {
-		t.Errorf("Unexpected %s: got %v, want %v", name, got, want)
-	}
-}
-
-func assertNonEmpty(t *testing.T, name, got string) {
-	if len(got) == 0 {
-		t.Errorf("Unexpected %s: non-empty string must be provided", name)
-	}
+	testutil.AssertEq(t, "repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
+	testutil.AssertNonEmpty(t, "subjectName", prov.Subject[0].Name)
+	testutil.AssertEq(t, "subjectDigest", len(prov.Subject[0].Digest["sha256"]), wantSHA256HexDigitLength)
+	testutil.AssertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSHA1HexDigitLength)
+	testutil.AssertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSHA256HexDigitLength)
+	testutil.AssertEq(t, "builderImageURI", predicate.Materials[0].URI, fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", predicate.Materials[0].Digest["sha256"]))
+	testutil.AssertNonEmpty(t, "command[0]", buildConfig.Command[0])
+	testutil.AssertNonEmpty(t, "command[1]", buildConfig.Command[1])
 }
 
 func checkBuildConfig(got *BuildConfig, t *testing.T) {
@@ -159,11 +147,11 @@ func checkBuildConfig(got *BuildConfig, t *testing.T) {
 		t.Fatalf("couldn't parse imageURI (%q): %v", got.BuilderImage, err)
 	}
 	// Check that the provenance is generated correctly
-	assertEq(t, "repoURL", got.Repo, "https://github.com/project-oak/oak")
-	assertEq(t, "commitHash length", len(got.CommitHash), wantSHA1HexDigitLength)
-	assertEq(t, "builderImageID length", len(digest), wantSHA256HexDigitLength)
-	assertEq(t, "builderImageID digest algorithm", alg, "sha256")
-	assertEq(t, "builderImageID length", len(digest), wantSHA256HexDigitLength)
-	assertNonEmpty(t, "command[0]", got.Command[0])
-	assertNonEmpty(t, "command[1]", got.Command[1])
+	testutil.AssertEq(t, "repoURL", got.Repo, "https://github.com/project-oak/oak")
+	testutil.AssertEq(t, "commitHash length", len(got.CommitHash), wantSHA1HexDigitLength)
+	testutil.AssertEq(t, "builderImageID length", len(digest), wantSHA256HexDigitLength)
+	testutil.AssertEq(t, "builderImageID digest algorithm", alg, "sha256")
+	testutil.AssertEq(t, "builderImageID length", len(digest), wantSHA256HexDigitLength)
+	testutil.AssertNonEmpty(t, "command[0]", got.Command[0])
+	testutil.AssertNonEmpty(t, "command[1]", got.Command[1])
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -41,7 +41,7 @@ func TestComputeBinarySha256Hash(t *testing.T) {
 		t.Fatalf("couldn't get SHA256 hash: %v", err)
 	}
 	if got != wantTOMLHash {
-		t.Errorf("invalid commit hash: got %s, want %s", got, wantTOMLHash)
+		t.Errorf("invalid SHA256 hash: got %s, want %s", got, wantTOMLHash)
 	}
 }
 
@@ -77,7 +77,7 @@ func TestLoadBuildConfigFromProvenance(t *testing.T) {
 	checkBuildConfig(config, t)
 }
 
-func TestParseBuilderImageUriValidUri(t *testing.T) {
+func TestParseBuilderImageURIValidURI(t *testing.T) {
 	builderImageURI := fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", wantBuilderImageID)
 	alg, digest, err := parseBuilderImageURI(builderImageURI)
 	if err != nil {
@@ -94,7 +94,7 @@ func TestParseBuilderImageUriValidUri(t *testing.T) {
 	}
 }
 
-func TestParseBuilderImageUriInvalidURIs(t *testing.T) {
+func TestParseBuilderImageURIInvalidURIs(t *testing.T) {
 	imageURIWithTag := "gcr.io/oak-ci/oak@latest"
 	want := fmt.Sprintf("the builder image digest (%q) does not have the required ALG:VALUE format", "latest")
 	alg, digest, err := parseBuilderImageURI(imageURIWithTag)

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -28,20 +28,20 @@ import (
 const (
 	testdataPath             = "../testdata/"
 	provenanceExamplePath    = "schema/amber-slsa-buildtype/v1/example.json"
-	wantTomlHash             = "f8b8b42df90a32f24822a5cf527574598a7812209455cf293bf99b84de90934b"
+	wantTOMLHash             = "322527c0260e25f0e9a2595bd0d71a52294fe2397a7af76165190fd98de8920d"
 	wantBuilderImageID       = "6e5beabe4ace0e3aaa01ce497f5f1ef30fed7c18c596f35621751176b1ab583d"
-	wantSha1HexDigitLength   = 40
-	wantSha256HexDigitLength = 64
+	wantSHA1HexDigitLength   = 40
+	wantSHA256HexDigitLength = 64
 )
 
 func TestComputeBinarySha256Hash(t *testing.T) {
-	path := filepath.Join(testdataPath, "build.toml")
+	path := filepath.Join(testdataPath, "static.txt")
 	got, err := computeSha256Hash(path)
 	if err != nil {
 		t.Fatalf("couldn't get SHA256 hash: %v", err)
 	}
-	if got != wantTomlHash {
-		t.Errorf("invalid commit hash: got %s, want %s", got, wantTomlHash)
+	if got != wantTOMLHash {
+		t.Errorf("invalid commit hash: got %s, want %s", got, wantTOMLHash)
 	}
 }
 
@@ -133,9 +133,9 @@ func TestGenerateProvenanceStatement(t *testing.T) {
 	// Check that the provenance is generated correctly
 	assertEq(t, "repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
 	assertNonEmpty(t, "subjectName", prov.Subject[0].Name)
-	assertEq(t, "subjectDigest", len(prov.Subject[0].Digest["sha256"]), wantSha256HexDigitLength)
-	assertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSha1HexDigitLength)
-	assertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSha256HexDigitLength)
+	assertEq(t, "subjectDigest", len(prov.Subject[0].Digest["sha256"]), wantSHA256HexDigitLength)
+	assertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSHA1HexDigitLength)
+	assertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSHA256HexDigitLength)
 	assertEq(t, "builderImageURI", predicate.Materials[0].URI, fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", predicate.Materials[0].Digest["sha256"]))
 	assertNonEmpty(t, "command[0]", buildConfig.Command[0])
 	assertNonEmpty(t, "command[1]", buildConfig.Command[1])
@@ -148,7 +148,7 @@ func assertEq[T comparable](t *testing.T, name string, got, want T) {
 }
 
 func assertNonEmpty(t *testing.T, name, got string) {
-	if len(got) <= 0 {
+	if len(got) == 0 {
 		t.Errorf("Unexpected %s: non-empty string must be provided", name)
 	}
 }
@@ -160,10 +160,10 @@ func checkBuildConfig(got *BuildConfig, t *testing.T) {
 	}
 	// Check that the provenance is generated correctly
 	assertEq(t, "repoURL", got.Repo, "https://github.com/project-oak/oak")
-	assertEq(t, "commitHash length", len(got.CommitHash), wantSha1HexDigitLength)
-	assertEq(t, "builderImageID length", len(digest), wantSha256HexDigitLength)
+	assertEq(t, "commitHash length", len(got.CommitHash), wantSHA1HexDigitLength)
+	assertEq(t, "builderImageID length", len(digest), wantSHA256HexDigitLength)
 	assertEq(t, "builderImageID digest algorithm", alg, "sha256")
-	assertEq(t, "builderImageID length", len(digest), wantSha256HexDigitLength)
+	assertEq(t, "builderImageID length", len(digest), wantSHA256HexDigitLength)
 	assertNonEmpty(t, "command[0]", got.Command[0])
 	assertNonEmpty(t, "command[1]", got.Command[1])
 }

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -24,3 +24,15 @@ func Chdir(t *testing.T, dir string) {
 		t.Fatalf("couldn't change directory to %s: %v", dir, err)
 	}
 }
+
+func AssertEq[T comparable](t *testing.T, name string, got, want T) {
+	if got != want {
+		t.Errorf("Unexpected %s: got %v, want %v", name, got, want)
+	}
+}
+
+func AssertNonEmpty(t *testing.T, name, got string) {
+	if len(got) == 0 {
+		t.Errorf("Unexpected %s: non-empty string must be provided", name)
+	}
+}

--- a/pkg/amber/provenance_test.go
+++ b/pkg/amber/provenance_test.go
@@ -15,6 +15,7 @@
 package amber
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -22,7 +23,11 @@ import (
 	"github.com/project-oak/transparent-release/internal/testutil"
 )
 
-const schemaExamplePath = "schema/amber-slsa-buildtype/v1/example.json"
+const (
+	provenanceExamplePath    = "schema/amber-slsa-buildtype/v1/example.json"
+	wantSha1HexDigitLength   = 40
+	wantSha256HexDigitLength = 64
+)
 
 func TestExampleProvenance(t *testing.T) {
 	// The path to provenance is specified relative to the root of the repo, so we need to go one level up.
@@ -35,29 +40,33 @@ func TestExampleProvenance(t *testing.T) {
 	testutil.Chdir(t, "../../")
 
 	// Parses the provenance and validates it against the schema.
-	provenance, err := ParseProvenanceFile(schemaExamplePath)
+	provenance, err := ParseProvenanceFile(provenanceExamplePath)
 	if err != nil {
 		t.Fatalf("Failed to parse example provenance: %v", err)
-	}
-
-	assert := func(name, got, want string) {
-		if want != got {
-			t.Errorf("Unexpected %s: got %s, want %s", name, got, want)
-		}
 	}
 
 	predicate := provenance.Predicate.(slsa.ProvenancePredicate)
 	buildConfig := predicate.BuildConfig.(BuildConfig)
 
 	// Check that the provenance parses correctly
-	assert("repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
-	assert("commitHash", predicate.Materials[1].Digest["sha1"], "0f2189703c57845e09d8ab89164a4041c0af0a62")
-	assert("builderImage", predicate.Materials[0].URI, "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320")
-	assert("commitHash", predicate.Materials[0].Digest["sha256"], "53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320")
-	assert("subjectName", provenance.Subject[0].Name, "oak_functions_loader")
-	assert("subjectDigest", provenance.Subject[0].Digest["sha256"], "15dc16c42a4ac9ed77f337a4a3065a63e444c29c18c8cf69d6a6b4ae678dca5c")
-	assert("outputPath", buildConfig.OutputPath, "./oak_functions/loader/bin/oak_functions_loader")
-	assert("command[0]", buildConfig.Command[0], "./scripts/runner")
-	assert("command[1]", buildConfig.Command[1], "build-functions-server")
-	assert("builderId", predicate.Builder.ID, "https://github.com/project-oak/transparent-release")
+	assertEq(t, "repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
+	assertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSha1HexDigitLength)
+	assertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSha256HexDigitLength)
+	assertEq(t, "builderImageURI", predicate.Materials[0].URI, fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", predicate.Materials[0].Digest["sha256"]))
+	assertEq(t, "subjectName", provenance.Subject[0].Name, "oak_functions_loader")
+	assertNonEmpty(t, "command[0]", buildConfig.Command[0])
+	assertNonEmpty(t, "command[1]", buildConfig.Command[1])
+	assertNonEmpty(t, "builderId", predicate.Builder.ID)
+}
+
+func assertEq[T comparable](t *testing.T, name string, got, want T) {
+	if got != want {
+		t.Errorf("Unexpected %s: got %v, want %v", name, got, want)
+	}
+}
+
+func assertNonEmpty(t *testing.T, name, got string) {
+	if len(got) <= 0 {
+		t.Errorf("Unexpected %s: non-empty string must be provided", name)
+	}
 }

--- a/pkg/amber/provenance_test.go
+++ b/pkg/amber/provenance_test.go
@@ -49,24 +49,12 @@ func TestExampleProvenance(t *testing.T) {
 	buildConfig := predicate.BuildConfig.(BuildConfig)
 
 	// Check that the provenance parses correctly
-	assertEq(t, "repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
-	assertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSha1HexDigitLength)
-	assertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSha256HexDigitLength)
-	assertEq(t, "builderImageURI", predicate.Materials[0].URI, fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", predicate.Materials[0].Digest["sha256"]))
-	assertEq(t, "subjectName", provenance.Subject[0].Name, "oak_functions_loader")
-	assertNonEmpty(t, "command[0]", buildConfig.Command[0])
-	assertNonEmpty(t, "command[1]", buildConfig.Command[1])
-	assertNonEmpty(t, "builderId", predicate.Builder.ID)
-}
-
-func assertEq[T comparable](t *testing.T, name string, got, want T) {
-	if got != want {
-		t.Errorf("Unexpected %s: got %v, want %v", name, got, want)
-	}
-}
-
-func assertNonEmpty(t *testing.T, name, got string) {
-	if len(got) == 0 {
-		t.Errorf("Unexpected %s: non-empty string must be provided", name)
-	}
+	testutil.AssertEq(t, "repoURL", predicate.Materials[1].URI, "https://github.com/project-oak/oak")
+	testutil.AssertEq(t, "commitHash length", len(predicate.Materials[1].Digest["sha1"]), wantSha1HexDigitLength)
+	testutil.AssertEq(t, "builderImageID length", len(predicate.Materials[0].Digest["sha256"]), wantSha256HexDigitLength)
+	testutil.AssertEq(t, "builderImageURI", predicate.Materials[0].URI, fmt.Sprintf("gcr.io/oak-ci/oak@sha256:%s", predicate.Materials[0].Digest["sha256"]))
+	testutil.AssertEq(t, "subjectName", provenance.Subject[0].Name, "oak_functions_loader")
+	testutil.AssertNonEmpty(t, "command[0]", buildConfig.Command[0])
+	testutil.AssertNonEmpty(t, "command[1]", buildConfig.Command[1])
+	testutil.AssertNonEmpty(t, "builderId", predicate.Builder.ID)
 }

--- a/pkg/amber/provenance_test.go
+++ b/pkg/amber/provenance_test.go
@@ -66,7 +66,7 @@ func assertEq[T comparable](t *testing.T, name string, got, want T) {
 }
 
 func assertNonEmpty(t *testing.T, name, got string) {
-	if len(got) <= 0 {
+	if len(got) == 0 {
 		t.Errorf("Unexpected %s: non-empty string must be provided", name)
 	}
 }

--- a/schema/amber-slsa-buildtype/v1/BUILD
+++ b/schema/amber-slsa-buildtype/v1/BUILD
@@ -20,5 +20,5 @@ licenses(["notice"])
 
 exports_files([
     "provenance.json",
-    "example.json"
+    "example.json",
 ])

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -20,4 +20,5 @@ licenses(["notice"])
 
 exports_files([
     "build.toml",
+    "static.txt",
 ])

--- a/testdata/build.toml
+++ b/testdata/build.toml
@@ -1,5 +1,5 @@
 repo = "https://github.com/project-oak/oak"
-commit_hash = "0f2189703c57845e09d8ab89164a4041c0af0a62"
-builder_image = "gcr.io/oak-ci/oak@sha256:53ca44b5889e2265c3ae9e542d7097b7de12ea4c6a33785da8478c7333b9a320"
-command = ["./scripts/runner", "build-functions-server"]
-output_path = "./oak_functions/loader/bin/oak_functions_loader"
+commit_hash = "d11e3de97b8fc1cf49e4ed8001d14d77b98c24b8"
+builder_image = "gcr.io/oak-ci/oak@sha256:6e5beabe4ace0e3aaa01ce497f5f1ef30fed7c18c596f35621751176b1ab583d"
+command = ["./scripts/xtask", "build-oak-functions-server-variants"]
+output_path = "./target/x86_64-unknown-linux-musl/release/oak_functions_loader_base"

--- a/testdata/static.txt
+++ b/testdata/static.txt
@@ -1,0 +1,1 @@
+DO NOT MODIFY!!!

--- a/verify/BUILD
+++ b/verify/BUILD
@@ -31,7 +31,7 @@ go_library(
 
 go_test(
     name = "verify_test",
-    size = "large",
+    size = "enormous",
     srcs = ["verify_test.go"],
     data = [
         "//schema/amber-slsa-buildtype/v1:example.json",


### PR DESCRIPTION
Currently most tests depend on the exact values in the testdata/example files. As a result if we update an example file, many changes are required in the tests. In most cases, the exact values are not relevant for the test logic, but rather the presence or absence of values needs to be checked. This PR updates the tests to check invariants on the values (e.g., length of a SHA256 hash) rather than the exact values. 