### PR TITLE
Enable gosec linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           go-version: "=1.18.4"
       - name: Run golint
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
           ./scripts/linting.sh
 
   vetting:

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 
 	log.Printf("Storing the provenance in %s", absProvenancePath)
-	if err := os.WriteFile(absProvenancePath, bytes, 0644); err != nil {
+	if err := os.WriteFile(absProvenancePath, bytes, 0600); err != nil {
 		log.Fatalf("Couldn't write the provenance file: %v", err)
 	}
 }

--- a/experimental/auth-logic/wrappers/endorsement_wrapper.go
+++ b/experimental/auth-logic/wrappers/endorsement_wrapper.go
@@ -31,7 +31,7 @@ const endorsementPolicyTemplate = "experimental/auth-logic/templates/endorsement
 
 // ValidatedEndorsement is a structure for holding data from endorsement
 // files that have been validated. It also simplifies the Endorsement
-// structure to contain just the relevant
+// structure to contain just the relevant fields.
 type ValidatedEndorsement struct {
 	Name        string
 	Sha256      string

--- a/experimental/auth-logic/wrappers/rekor_wrapper.go
+++ b/experimental/auth-logic/wrappers/rekor_wrapper.go
@@ -44,7 +44,7 @@ import (
 // -- verifying the signature in `body.RekordObj.signature`, using Oak's public key,
 // -- verifying that the contents of the body matches the input `endorsement_bytes`
 // -- verifying the signature in `signedEntryTimestamp`, using Rekor's public key
-// --  validating the inclusion proof
+// --  validating the inclusion proof.
 type RekorLogWrapper struct {
 	rekorLogEntryBytes  []byte
 	productTeamKeyBytes []byte
@@ -118,7 +118,7 @@ func getRekorEntryFromEntryImpl(entryImpl types.EntryImpl) (*rekord.V001Entry, e
 // Verify signature in a rekor entry. In the context where this is used,
 // this will verify the contents of a rekor entry (an endorsement file)
 // against the product team's public key. It returns the public key if and only
-// if the signature is valid
+// if the signature is valid.
 func verifyRekorLogSignature(rekorEntry *rekord.V001Entry) (*ecdsa.PublicKey, error) {
 	publicKeyBytes := rekorEntry.RekordObj.Signature.PublicKey.Content
 	ecdsaKey, err := pubKeyBytesToECDSA(publicKeyBytes)
@@ -158,7 +158,7 @@ func pubKeyBytesToECDSA(keyData []byte) (*ecdsa.PublicKey, error) {
 // (*models.LogEntryAnon).Validate(...) will check the inclusion proof in
 // LogEntryAnon.Verification, but only if it is non-empty. If it is empty
 // it will not error, so this function just throws an error if the verification
-// is empty
+// is empty.
 func checkInclusionProof(logEntryAnon *models.LogEntryAnon) error {
 	if logEntryAnon.Verification == nil {
 		return fmt.Errorf("logEntryAnon did not have inclusion proof")
@@ -208,7 +208,7 @@ func verifySignedEntryTimestamp(logEntryAnon *models.LogEntryAnon, rekorPublicKe
 // checkEntryPubKeyMatchesExpectedKey compares the public key of the product
 // team in the Rekor log entry to the key of the product team passed as an
 // input to this wrapper. It returns an error if they are not equal
-// (or if valid keys could not be constructed)
+// (or if valid keys could not be constructed).
 func checkEntryPubKeyMatchesExpectedKey(rekorEntry *rekord.V001Entry, prodTeamKeyBytes []byte) error {
 	logECDSAPubKey, err := pubKeyBytesToECDSA(rekorEntry.RekordObj.Signature.PublicKey.Content)
 	if err != nil {

--- a/golangci-linters.yaml
+++ b/golangci-linters.yaml
@@ -52,7 +52,7 @@ linters:
     - gomoddirectives
     - gomodguard
     - goprintffuncname
-    # - gosec
+    - gosec
     - gosimple
     - govet
     - grouper
@@ -155,7 +155,7 @@ linters:
     # - gomoddirectives
     # - gomodguard
     # - goprintffuncname
-    - gosec
+    # - gosec
     # - gosimple
     # - govet
     # - grouper

--- a/golangci-linters.yaml
+++ b/golangci-linters.yaml
@@ -47,7 +47,6 @@ linters:
     # - gofumpt
     - goheader
     - goimports
-    - golint
     # - gomnd
     - gomoddirectives
     - gomodguard
@@ -56,16 +55,14 @@ linters:
     - gosimple
     - govet
     - grouper
-    - ifshort
     - importas
     - ineffassign
-    - interfacer
     # - ireturn
     # Line length: Would be nice to enable it later.
     # - lll
     - maintidx
     - makezero
-    - maligned
+    # - maligned
     - misspell
     - nakedret
     - nestif
@@ -84,12 +81,11 @@ linters:
     - promlinter
     - revive
     - rowserrcheck
-    - scopelint
     - sqlclosecheck
     - staticcheck
     - structcheck
     - stylecheck
-    # - tagliatelle
+    - tagliatelle
     - tenv
     # - testpackage
     # Consider enabling it later.
@@ -150,7 +146,6 @@ linters:
     - gofumpt
     # - goheader
     # - goimports
-    # - golint
     - gomnd
     # - gomoddirectives
     # - gomodguard
@@ -159,15 +154,13 @@ linters:
     # - gosimple
     # - govet
     # - grouper
-    # - ifshort
+    - ifshort
     # - importas
     # - ineffassign
-    # - interfacer
     - ireturn
     - lll
     # - maintidx
     # - makezero
-    # - maligned
     # - misspell
     # - nakedret
     # - nestif
@@ -185,12 +178,12 @@ linters:
     # - promlinter
     # - revive
     # - rowserrcheck
-    # - scopelint
+    - scopelint
     # - sqlclosecheck
     # - staticcheck
     # - structcheck
     # - stylecheck
-    - tagliatelle
+    # - tagliatelle
     # - tenv
     - testpackage
     - thelper

--- a/golangci-linters.yaml
+++ b/golangci-linters.yaml
@@ -21,33 +21,29 @@ linters:
     - errcheck
     - errchkjson
     - errname
-    # - errorlint
+    # - errorlint # expects using `%w` to format errors.
     - execinquery
     - exhaustive
-    # - exhaustivestruct
-    # - exhaustruct
+    # - exhaustivestruct # expects all fields in a struct to be initialized
     - exportloopref
     - forbidigo
-    # Might be nice to enable it later.
-    # - forcetypeassert
-    # - funlen
-    # - gci
+    # - forcetypeassert # expects checking the result of type conversions
+    # - funlen # expects function length to be less than 60 lines.
     - gochecknoglobals
     - gochecknoinits
     - gocognit
     - goconst
-    # - gocritic
-    - gocyclo
-    # - godot
-    # TODO/BUG/FIXME: would be nice to enable it later.
-    # - godox
     # Consider enabling it.
-    # - goerr113
+    # - gocritic # suggestions for simplifying the code.
+    - gocyclo
+    # - godot # expects comments to end in a period.
+    # - godox # Reports TODO/BUG/FIXME;
+    # - goerr113 # expects using wrapped static errors instead of dynamic errors.
     - gofmt
-    # - gofumpt
+    # - gofumpt # expects files to be formatted with https://github.com/mvdan/gofumpt, which is stricter than gofmt.
     - goheader
     - goimports
-    # - gomnd
+    # - gomnd # reports magic numbers (e.g., file permissions.)
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -57,18 +53,15 @@ linters:
     - grouper
     - importas
     - ineffassign
-    # - ireturn
-    # Line length: Would be nice to enable it later.
-    # - lll
+    # - lll # Line length: Would be nice to enable it later.
     - maintidx
     - makezero
-    # - maligned
     - misspell
     - nakedret
     - nestif
     - nilerr
     - nilnil
-    # - nlreturn
+    # - nlreturn # expects some additional blank lines
     - noctx
     - nolintlint
     - nonamedreturns
@@ -88,8 +81,7 @@ linters:
     - tagliatelle
     - tenv
     # - testpackage
-    # Consider enabling it later.
-    # - thelper
+    # - thelper # expects helper functions to start from t.Helper.
     - tparallel
     - typecheck
     - unconvert
@@ -99,8 +91,8 @@ linters:
     - varnamelen
     - wastedassign
     - whitespace
-    # - wrapcheck
-    # - wsl
+    # - wrapcheck # expects errors to be wrapped in additional message
+    # - wsl # expects additional new lines here and there.
   # Enable all available linters.
   # Default: false
   # enable-all: true
@@ -127,7 +119,6 @@ linters:
     # - execinquery
     # - exhaustive
     - exhaustivestruct
-    - exhaustruct
     # - exportloopref
     # - forbidigo
     - forcetypeassert
@@ -141,7 +132,7 @@ linters:
     # - gocyclo
     - godot
     - godox
-    # - goerr113
+    - goerr113
     # - gofmt
     - gofumpt
     # - goheader
@@ -157,7 +148,6 @@ linters:
     - ifshort
     # - importas
     # - ineffassign
-    - ireturn
     - lll
     # - maintidx
     # - makezero

--- a/pkg/amber/provenance.go
+++ b/pkg/amber/provenance.go
@@ -34,7 +34,7 @@ const (
 	// AmberBuildTypeV1 is the SLSA BuildType for Amber builds.
 	AmberBuildTypeV1 = "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json"
 
-	// SchemaPath is the path to Amber SLSA buildType schema
+	// SchemaPath is the path to Amber SLSA buildType schema.
 	SchemaPath = "schema/amber-slsa-buildtype/v1/provenance.json"
 )
 

--- a/schema/amber-endorsement/v1/endorsement_test.go
+++ b/schema/amber-endorsement/v1/endorsement_test.go
@@ -17,7 +17,6 @@ package schema
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"testing"
 
@@ -28,14 +27,17 @@ func TestExampleAmberEndorsement(t *testing.T) {
 	schemaPath := "statement.json"
 	examplePath := "example.json"
 
-	schemaLoader, err := loadJSON(schemaPath)
+	fileContent, err := os.ReadFile(schemaPath)
 	if err != nil {
-		t.Fatalf("Couldn't load schema file %v: %v", schemaPath, err)
+		t.Fatalf("Couldn't read the schema file %v: %v", schemaPath, err)
 	}
-	exampleLoader, err := loadJSON(examplePath)
+	schemaLoader := gojsonschema.NewStringLoader(string(fileContent))
+
+	fileContent, err = os.ReadFile(examplePath)
 	if err != nil {
-		t.Fatalf("Couldn't load example file %v: %v", examplePath, err)
+		t.Fatalf("Couldn't read the example file %v: %v", examplePath, err)
 	}
+	exampleLoader := gojsonschema.NewStringLoader(string(fileContent))
 
 	result, err := gojsonschema.Validate(schemaLoader, exampleLoader)
 	if err != nil {
@@ -51,15 +53,4 @@ func TestExampleAmberEndorsement(t *testing.T) {
 
 		t.Fatalf("Failed to validate the example endorsement file: %v", buffer.String())
 	}
-}
-
-func loadJSON(path string) (gojsonschema.JSONLoader, error) {
-	jsonFile, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't read json file %v: %v", path, err)
-	}
-
-	jsonLoader := gojsonschema.NewStringLoader(string(jsonFile))
-
-	return jsonLoader, nil
 }


### PR DESCRIPTION
Fixes #117

This PR
* Enables `gosec` linter as a result of which the permission for writing the provenance file is changed from `0644` to `0600`. 
* Enables the `tagliatelle` linter.
* Removes deprecated linters from the linting config in golangci-linters.yaml. 

- [x] Tests pass
- [x] Appropriate changes to README are included in PR