### PR TITLE
Make computeSHA256Digest public

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -221,7 +221,7 @@ func (b *BuildConfig) VerifyCommit() error {
 // ComputeBinarySHA256Digest computes the SHA256 digest of the file in the
 // `OutputPath` of this BuildConfig.
 func (b *BuildConfig) ComputeBinarySHA256Digest() (string, error) {
-	binarySHA256Digest, err := computeSHA256Digest(b.OutputPath)
+	binarySHA256Digest, err := ComputeSHA256Digest(b.OutputPath)
 	if err != nil {
 		return "", fmt.Errorf("couldn't compute SHA256 digest of %q: %v", b.OutputPath, err)
 	}
@@ -425,7 +425,9 @@ func FetchSourcesFromRepo(repoURL, commitHash string) (*RepoCheckoutInfo, error)
 	return &info, nil
 }
 
-func computeSHA256Digest(path string) (string, error) {
+// ComputeSHA256Digest returns the SHA256 digest of the file in the given path, or an error if the
+// file cannot be read.
+func ComputeSHA256Digest(path string) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("couldn't read file %q: %v", path, err)

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -35,7 +35,7 @@ const (
 
 func TestComputeBinarySHA256Digest(t *testing.T) {
 	path := filepath.Join(testdataPath, "static.txt")
-	got, err := computeSHA256Digest(path)
+	got, err := ComputeSHA256Digest(path)
 	if err != nil {
 		t.Fatalf("couldn't get SHA256 digest: %v", err)
 	}


### PR DESCRIPTION
This is a basic functionality we often use. Making it public to allow reusing it in other parts of the code too. 