### PR TITLE
Refactor ReproducibleProvenanceVerifier

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -69,7 +69,7 @@ binary has a SHA256 hash equal to the expected digest given in the provenance fi
 To verify a SLSA provenance of the Amber build type run:
 
 ```bash
-$ go run cmd/verifier/main.go -config schema/provenance/v1/example.json
+$ go run cmd/verifier/main.go -provenance_path schema/provenance/v1/example.json
 ```
 
 This fetches the sources from the Git repository specified in the SLSA statement file, re-runs the
@@ -84,6 +84,6 @@ error otherwise.
 
 ```bash
 $ go run cmd/verifier/main.go \
-  -config schema/provenance/v1/example.json \
+  -provenance_path schema/provenance/v1/example.json \
   -git_root_dir <path-to-git-repo-root>
 ```

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -24,16 +24,15 @@ import (
 )
 
 func main() {
-	// TODO(mschett): I think this is wrong.
-	buildConfigPathPtr := flag.String("config", "",
+	provenance_path := flag.String("provenance_path", "",
 		"Required - Path to SLSA provenance file of the Amber build type.")
 	gitRootDirPtr := flag.String("git_root_dir", "",
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
 	flag.Parse()
 
-	provenance, err := amber.ParseProvenanceFile(*buildConfigPathPtr)
+	provenance, err := amber.ParseProvenanceFile(*provenance_path)
 	if err != nil {
-		log.Fatalf("couldn't load the provenance file from %s: %v", *buildConfigPathPtr, err)
+		log.Fatalf("couldn't load the provenance file from %s: %v", *provenance_path, err)
 		return
 	}
 

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -24,15 +24,15 @@ import (
 )
 
 func main() {
-	provenance_path := flag.String("provenance_path", "",
-		"Required - Path to SLSA provenance file of the Amber build type.")
+	provenancePath := flag.String("provenance_path", "",
+		"Required - Path to SLSA provenance file of th.e Amber build type.")
 	gitRootDirPtr := flag.String("git_root_dir", "",
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
 	flag.Parse()
 
-	provenance, err := amber.ParseProvenanceFile(*provenance_path)
+	provenance, err := amber.ParseProvenanceFile(*provenancePath)
 	if err != nil {
-		log.Fatalf("couldn't load the provenance file from %s: %v", *provenance_path, err)
+		log.Fatalf("couldn't load the provenance file from %s: %v", *provenancePath, err)
 		return
 	}
 

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	provenanceVerifier := verifier.ReproducibleProvenanceVerifier{
-		provenance: *provenance,
+		Provenance: provenance,
 		GitRootDir: *gitRootDirPtr,
 	}
 

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -20,20 +20,29 @@ import (
 	"log"
 
 	"github.com/project-oak/transparent-release/internal/verifier"
+	"github.com/project-oak/transparent-release/pkg/amber"
 )
 
 func main() {
+	// TODO(mschett): I think this is wrong.
 	buildConfigPathPtr := flag.String("config", "",
 		"Required - Path to SLSA provenance file of the Amber build type.")
 	gitRootDirPtr := flag.String("git_root_dir", "",
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
 	flag.Parse()
 
+	provenance, err := amber.ParseProvenanceFile(*buildConfigPathPtr)
+	if err != nil {
+		log.Fatalf("couldn't load the provenance file from %s: %v", *buildConfigPathPtr, err)
+		return
+	}
+
 	provenanceVerifier := verifier.ReproducibleProvenanceVerifier{
+		provenance: *provenance,
 		GitRootDir: *gitRootDirPtr,
 	}
 
-	if err := provenanceVerifier.Verify(*buildConfigPathPtr); err != nil {
+	if err := provenanceVerifier.Verify(); err != nil {
 		log.Fatalf("error when verifying the provenance: %v", err)
 	}
 }

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	provenancePath := flag.String("provenance_path", "",
-		"Required - Path to SLSA provenance file of th.e Amber build type.")
+		"Required - Path to SLSA provenance file of the Amber build type.")
 	gitRootDirPtr := flag.String("git_root_dir", "",
 		"Optional - Root of the Git repository. If not specified, sources are fetched from the repo specified in the config file.")
 	flag.Parse()

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -36,7 +36,7 @@ type ProvenanceVerifier interface {
 // specified in the provenance and checking that the hash of the binary is the
 // same as the digest in the subject of the provenance file.
 type ReproducibleProvenanceVerifier struct {
-	provenance *amber.ValidatedProvenance
+	Provenance *amber.ValidatedProvenance
 	GitRootDir string
 }
 
@@ -54,7 +54,7 @@ func (verifier *ReproducibleProvenanceVerifier) Verify() error {
 	}
 	defer chdir(currentDir)
 
-	buildConfig, err := common.LoadBuildConfigFromProvenance(verifier.provenance)
+	buildConfig, err := common.LoadBuildConfigFromProvenance(verifier.Provenance)
 	if err != nil {
 		return fmt.Errorf("couldn't load BuildConfig from provenance: %v", err)
 	}
@@ -74,7 +74,7 @@ func (verifier *ReproducibleProvenanceVerifier) Verify() error {
 	}
 
 	// The provenance is valid, therefore `expectedBinaryHash` is guaranteed to be non-empty.
-	expectedBinaryDigest := verifier.provenance.GetBinarySHA256Digest()
+	expectedBinaryDigest := verifier.Provenance.GetBinarySHA256Digest()
 
 	if err := buildConfig.VerifyBinarySHA256Digest(expectedBinaryDigest); err != nil {
 		return fmt.Errorf("failed to verify the digest of the built binary: %v", err)

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -28,6 +28,7 @@ import (
 // ProvenanceVerifier defines an interface with a single method `Verify` for
 // verifying provenances.
 type ProvenanceVerifier interface {
+	// Verifies a provenance.
 	Verify() error
 }
 

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -37,7 +37,7 @@ func TestReproducibleProvenanceVerifier_validProvenance(t *testing.T) {
 	}
 
 	verifier := ReproducibleProvenanceVerifier{
-		provenance: provenance,
+		Provenance: provenance,
 	}
 
 	if err := verifier.Verify(); err != nil {
@@ -54,7 +54,7 @@ func TestReproducibleProvenanceVerifier_invalidHash(t *testing.T) {
 	}
 
 	verifier := ReproducibleProvenanceVerifier{
-		provenance: provenance,
+		Provenance: provenance,
 	}
 
 	want := "failed to verify the digest of the built binary"
@@ -73,7 +73,7 @@ func TestReproducibleProvenanceVerifier_badCommand(t *testing.T) {
 	}
 
 	verifier := ReproducibleProvenanceVerifier{
-		provenance: provenance,
+		Provenance: provenance,
 	}
 
 	want := "couldn't build the binary"
@@ -91,7 +91,7 @@ func TestAmberProvenanceMetadataVerifier(t *testing.T) {
 	}
 
 	verifier := ReproducibleProvenanceVerifier{
-		provenance: provenance,
+		Provenance: provenance,
 	}
 
 	if err := verifier.Verify(); err != nil {

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/project-oak/transparent-release/pkg/amber"
 )
 
 const (
@@ -29,10 +31,16 @@ const (
 
 func TestReproducibleProvenanceVerifier_validProvenance(t *testing.T) {
 	path := filepath.Join(testdataPath, validProvenancePath)
+	provenance, err := amber.ParseProvenanceFile(path)
+	if err != nil {
+		t.Fatalf("couldn't load the provenance file from %s: %v", path, err)
+	}
 
-	verifier := ReproducibleProvenanceVerifier{}
+	verifier := ReproducibleProvenanceVerifier{
+		provenance: provenance,
+	}
 
-	if err := verifier.Verify(path); err != nil {
+	if err := verifier.Verify(); err != nil {
 		t.Fatalf("couldn't verify the provenance file: %v", err)
 	}
 }
@@ -40,12 +48,18 @@ func TestReproducibleProvenanceVerifier_validProvenance(t *testing.T) {
 // TODO(#126): Update the test once Verify is refactored.
 func TestReproducibleProvenanceVerifier_invalidHash(t *testing.T) {
 	path := filepath.Join(testdataPath, invalidHashProvenancePath)
+	provenance, err := amber.ParseProvenanceFile(path)
+	if err != nil {
+		t.Fatalf("couldn't load the provenance file from %s: %v", path, err)
+	}
 
-	verifier := ReproducibleProvenanceVerifier{}
+	verifier := ReproducibleProvenanceVerifier{
+		provenance: provenance,
+	}
 
 	want := "failed to verify the digest of the built binary"
 
-	if got := verifier.Verify(path); !strings.Contains(got.Error(), want) {
+	if got := verifier.Verify(); !strings.Contains(got.Error(), want) {
 		t.Fatalf("got %v, want error message containing %q,", got, want)
 	}
 }
@@ -53,22 +67,34 @@ func TestReproducibleProvenanceVerifier_invalidHash(t *testing.T) {
 // TODO(#126): Update the test once Verify is refactored.
 func TestReproducibleProvenanceVerifier_badCommand(t *testing.T) {
 	path := filepath.Join(testdataPath, badCommandProvenancePath)
+	provenance, err := amber.ParseProvenanceFile(path)
+	if err != nil {
+		t.Fatalf("couldn't load the provenance file from %s: %v", path, err)
+	}
 
-	verifier := ReproducibleProvenanceVerifier{}
+	verifier := ReproducibleProvenanceVerifier{
+		provenance: provenance,
+	}
 
 	want := "couldn't build the binary"
 
-	if got := verifier.Verify(path); !strings.Contains(got.Error(), want) {
+	if got := verifier.Verify(); !strings.Contains(got.Error(), want) {
 		t.Fatalf("got %v, want error message containing %q,", got, want)
 	}
 }
 
 func TestAmberProvenanceMetadataVerifier(t *testing.T) {
 	path := filepath.Join(testdataPath, validProvenancePath)
+	provenance, err := amber.ParseProvenanceFile(path)
+	if err != nil {
+		t.Fatalf("couldn't load the provenance file from %s: %v", path, err)
+	}
 
-	verifier := AmberProvenanceMetadataVerifier{}
+	verifier := ReproducibleProvenanceVerifier{
+		provenance: provenance,
+	}
 
-	if err := verifier.Verify(path); err != nil {
+	if err := verifier.Verify(); err != nil {
 		t.Fatalf("couldn't verify the provenance file: %v", err)
 	}
 }

--- a/testdata/provenance.json
+++ b/testdata/provenance.json
@@ -1,1 +1,43 @@
-{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","subject":[{"name":"test.txt-9b5f98310dbbad675834474fa68c37d880687cb9","digest":{"sha256":"322527c0260e25f0e9a2595bd0d71a52294fe2397a7af76165190fd98de8920d"}}],"predicate":{"builder":{"id":""},"buildType":"https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json","invocation":{"configSource":{}},"buildConfig":{"command":["cp","testdata/static.txt","test.txt"],"outputPath":"test.txt"},"materials":[{"uri":"bash@sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9","digest":{"sha256":"9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"}},{"uri":"https://github.com/project-oak/transparent-release","digest":{"sha1":"9b5f98310dbbad675834474fa68c37d880687cb9"}}]}}
+{
+    "_type": "https://in-toto.io/Statement/v0.1",
+    "predicateType": "https://slsa.dev/provenance/v0.2",
+    "subject": [
+        {
+            "name": "test.txt-9b5f98310dbbad675834474fa68c37d880687cb9",
+            "digest": {
+                "sha256": "322527c0260e25f0e9a2595bd0d71a52294fe2397a7af76165190fd98de8920d"
+            }
+        }
+    ],
+    "predicate": {
+        "builder": {
+            "id": ""
+        },
+        "buildType": "https://github.com/project-oak/transparent-release/schema/amber-slsa-buildtype/v1/provenance.json",
+        "invocation": {
+            "configSource": {}
+        },
+        "buildConfig": {
+            "command": [
+                "cp",
+                "testdata/static.txt",
+                "test.txt"
+            ],
+            "outputPath": "test.txt"
+        },
+        "materials": [
+            {
+                "uri": "bash@sha256:9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9",
+                "digest": {
+                    "sha256": "9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
+                }
+            },
+            {
+                "uri": "https://github.com/project-oak/transparent-release",
+                "digest": {
+                    "sha1": "9b5f98310dbbad675834474fa68c37d880687cb9"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- Change interface of `Verifier` from `Verify(path)` to `Verify()`, which makes implementing a `Verifier` flexible.
- Make type of provenace of `ReproducibleProvenanceVerifier` explicit by adding the field `*amber.ValidatedProvenance`
- Seperate parsing the `*amber.ValidatedProvenance` from the Verifier.
- Fix naming of `verifer` flag from `config` to `provenance_path`

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR