### PR TITLE
Refactor to generalize endorser

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -188,7 +188,6 @@ func (p *ProvenanceIR) GetBinaryName() (string, error) {
 }
 
 // FromProvenance validates and converts a provenance of arbitrary type to ProvenanceIR
-// TODO(#165): Remove types.ValidatedProvenance and perform the conversion directly on an intoto.statement.
 //
 // To add a new mapping from a provenance P write `fromP`, which sets every required field `X` from `ProvenanceIR` using `WithX`.
 func FromProvenance(prov *types.ValidatedProvenance) (*ProvenanceIR, error) {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -102,12 +102,9 @@ func NewProvenanceIR(binarySHA256Digest string, buildType string, options ...fun
 	return provenance
 }
 
-// GetBinarySHA256Digest gets the binary sha256 digest. Returns an error if the binary sha256 digest is empty.
-func (p *ProvenanceIR) GetBinarySHA256Digest() (string, error) {
-	if p.binarySHA256Digest == "" {
-		return "", fmt.Errorf("provenance does not have a binary SHA256 digest")
-	}
-	return p.binarySHA256Digest, nil
+// GetBinarySHA256Digest gets the binary sha256 digest.
+func (p *ProvenanceIR) GetBinarySHA256Digest() string {
+	return p.binarySHA256Digest
 }
 
 // WithBuildCmd sets the build cmd when creating a new ProvenanceIR.
@@ -187,10 +184,11 @@ func (p *ProvenanceIR) GetBinaryName() (string, error) {
 	return *p.binaryName, nil
 }
 
-// FromProvenance validates and converts a provenance of arbitrary type to ProvenanceIR
+// FromValidatedProvenance maps a validated provenance to ProvenanceIR by checking the provenance's
+// predicate and build type.
 //
 // To add a new mapping from a provenance P write `fromP`, which sets every required field `X` from `ProvenanceIR` using `WithX`.
-func FromProvenance(prov *types.ValidatedProvenance) (*ProvenanceIR, error) {
+func FromValidatedProvenance(prov *types.ValidatedProvenance) (*ProvenanceIR, error) {
 	predType := prov.PredicateType()
 	switch predType {
 	case intoto.SLSAV02PredicateType:

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -161,7 +161,9 @@ func TestFromProvenance_Amber(t *testing.T) {
 		amber.AmberBuildTypeV1,
 		WithBuildCmd([]string{"cp", "testdata/static.txt", "test.txt"}),
 		WithBuilderImageSHA256Digest("9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"),
-		WithRepoURIs([]string{"https://github.com/project-oak/transparent-release"}))
+		WithRepoURIs([]string{"https://github.com/project-oak/transparent-release"}),
+		WithBinaryName("test.txt-9b5f98310dbbad675834474fa68c37d880687cb9"),
+	)
 
 	got, err := FromProvenance(provenance)
 	if err != nil {

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -165,7 +165,7 @@ func TestFromProvenance_Amber(t *testing.T) {
 		WithBinaryName("test.txt-9b5f98310dbbad675834474fa68c37d880687cb9"),
 	)
 
-	got, err := FromProvenance(provenance)
+	got, err := FromValidatedProvenance(provenance)
 	if err != nil {
 		t.Fatalf("couldn't map provenance to ProvenanceIR: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestFromProvenance_Slsav02(t *testing.T) {
 		slsav02.GenericSLSABuildType,
 		WithRepoURIs([]string{"git+https://github.com/project-oak/oak@refs/heads/main"}))
 
-	got, err := FromProvenance(provenance)
+	got, err := FromValidatedProvenance(provenance)
 	if err != nil {
 		t.Fatalf("couldn't map provenance to ProvenanceIR: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestFromProvenance_Slsav1(t *testing.T) {
 
 	// Currently SLSA v1.0 provenances are not supported, so we expect an error.
 	want := fmt.Sprintf("unsupported predicateType (%q) for provenance", "https://slsa.dev/provenance/v1.0")
-	_, err = FromProvenance(provenance)
+	_, err = FromValidatedProvenance(provenance)
 	got := fmt.Sprintf("%v", err)
 
 	if got != want {

--- a/internal/common/common_test.go
+++ b/internal/common/common_test.go
@@ -158,11 +158,10 @@ func TestFromProvenance_Amber(t *testing.T) {
 	}
 
 	want := NewProvenanceIR("322527c0260e25f0e9a2595bd0d71a52294fe2397a7af76165190fd98de8920d",
-		amber.AmberBuildTypeV1,
+		amber.AmberBuildTypeV1, "test.txt-9b5f98310dbbad675834474fa68c37d880687cb9",
 		WithBuildCmd([]string{"cp", "testdata/static.txt", "test.txt"}),
 		WithBuilderImageSHA256Digest("9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"),
 		WithRepoURIs([]string{"https://github.com/project-oak/transparent-release"}),
-		WithBinaryName("test.txt-9b5f98310dbbad675834474fa68c37d880687cb9"),
 	)
 
 	got, err := FromValidatedProvenance(provenance)
@@ -187,8 +186,9 @@ func TestFromProvenance_Slsav02(t *testing.T) {
 	}
 
 	want := NewProvenanceIR("d059c38cea82047ad316a1c6c6fbd13ecf7a0abdcc375463920bd25bf5c142cc",
-		slsav02.GenericSLSABuildType,
-		WithRepoURIs([]string{"git+https://github.com/project-oak/oak@refs/heads/main"}))
+		slsav02.GenericSLSABuildType, "oak_functions_freestanding_bin",
+		WithRepoURIs([]string{"git+https://github.com/project-oak/oak@refs/heads/main"}),
+	)
 
 	got, err := FromValidatedProvenance(provenance)
 	if err != nil {

--- a/internal/endorser/endorser.go
+++ b/internal/endorser/endorser.go
@@ -64,12 +64,14 @@ func loadAndVerifyProvenances(referenceValues *common.ReferenceValues, provenanc
 	for _, uri := range provenanceURIs {
 		provenanceBytes, err := getProvenanceBytes(uri)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't load the provenance file from %s: %v", uri, err)
+			return nil, fmt.Errorf("couldn't load the provenance bytes from %s: %v", uri, err)
 		}
+		// Parse into a validated provenance to get the predicate/build type of the provenance.
 		validatedProvenance, err := types.ParseStatementData(provenanceBytes)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't parse bytes from %s into a provenance statement: %v", uri, err)
+			return nil, fmt.Errorf("couldn't parse bytes from %s into a validated provenance: %v", uri, err)
 		}
+		// Maps to internal provenance represenation based on the predicate/build type.
 		provenanceIR, err := common.FromValidatedProvenance(validatedProvenance)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't map from %s to internal representation: %v", validatedProvenance, err)

--- a/internal/endorser/endorser.go
+++ b/internal/endorser/endorser.go
@@ -71,7 +71,7 @@ func loadAndVerifyProvenances(referenceValues *common.ReferenceValues, provenanc
 		if err != nil {
 			return nil, fmt.Errorf("couldn't parse bytes from %s into a validated provenance: %v", uri, err)
 		}
-		// Maps to internal provenance represenation based on the predicate/build type.
+		// Map to internal provenance representation based on the predicate/build type.
 		provenanceIR, err := common.FromValidatedProvenance(validatedProvenance)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't map from %s to internal representation: %v", validatedProvenance, err)

--- a/internal/endorser/endorser.go
+++ b/internal/endorser/endorser.go
@@ -99,15 +99,9 @@ func loadAndVerifyProvenances(referenceValues *common.ReferenceValues, provenanc
 		return nil, fmt.Errorf("verification of provenances failed: %v", result.Justifications)
 	}
 
-	refBinaryDigest := provenanceIRs[0].GetBinarySHA256Digest()
-	refBinaryName, err := provenanceIRs[0].GetBinaryName()
-	if err != nil {
-		return nil, fmt.Errorf("provenance does not have binary name: %v", err)
-	}
-
 	verifiedProvenances := amber.VerifiedProvenanceSet{
-		BinaryDigest: refBinaryDigest,
-		BinaryName:   refBinaryName,
+		BinaryDigest: provenanceIRs[0].GetBinarySHA256Digest(),
+		BinaryName:   provenanceIRs[0].GetBinaryName(),
 		Provenances:  provenancesData,
 	}
 
@@ -143,12 +137,10 @@ func verifyProvenances(referenceValues *common.ReferenceValues, provenances []co
 // TODO(b/222440937): Perform any additional verification among provenances to ensure their consistency.
 func verifyConsistency(provenanceIRs []common.ProvenanceIR) (verifier.VerificationResult, error) {
 	result := verifier.NewVerificationResult()
-	// get the binary digest and binary name as the first provenance as reference
+	// get the binary digest and binary name of the first provenance as reference
 	refBinaryDigest := provenanceIRs[0].GetBinarySHA256Digest()
-	refBinaryName, err := provenanceIRs[0].GetBinaryName()
-	if err != nil {
-		return result, fmt.Errorf("provenance does not have binary name: %v", err)
-	}
+	refBinaryName := provenanceIRs[0].GetBinaryName()
+
 	// verify that all remaining provenances have the same binary digest and binary name.
 	for ind := 1; ind < len(provenanceIRs); ind++ {
 		if provenanceIRs[ind].GetBinarySHA256Digest() != refBinaryDigest {
@@ -157,10 +149,8 @@ func verifyConsistency(provenanceIRs []common.ProvenanceIR) (verifier.Verificati
 				provenanceIRs[ind].GetBinarySHA256Digest(), refBinaryDigest))
 		}
 
-		binaryName, err := provenanceIRs[ind].GetBinaryName()
-		if err != nil {
-			return result, fmt.Errorf("provenance #%d does not have binary name: %v", ind, err)
-		}
+		binaryName := provenanceIRs[ind].GetBinaryName()
+
 		if binaryName != refBinaryName {
 			result.SetFailed(
 				fmt.Sprintf("provenances are not consistent: unexpected subject name in provenance #%d; got %q, want %q",

--- a/internal/endorser/endorser.go
+++ b/internal/endorser/endorser.go
@@ -167,7 +167,6 @@ func verifyConsistency(provenanceIRs []common.ProvenanceIR) (verifier.Verificati
 					ind,
 					binaryName, refBinaryName))
 		}
-
 	}
 	return result, nil
 }

--- a/internal/endorser/endorser.go
+++ b/internal/endorser/endorser.go
@@ -84,10 +84,7 @@ func loadAndVerifyProvenances(referenceValues *common.ReferenceValues, provenanc
 		})
 	}
 
-	result, err := verifyConsistency(provenanceIRs)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't verify consistency of provenances: %v", err)
-	}
+	result := verifyConsistency(provenanceIRs)
 
 	verifyResult, err := verifyProvenances(referenceValues, provenanceIRs)
 	if err != nil {
@@ -135,7 +132,7 @@ func verifyProvenances(referenceValues *common.ReferenceValues, provenances []co
 // verifyConsistency verifies that all provenances have the same binary name and
 // binary digest.
 // TODO(b/222440937): Perform any additional verification among provenances to ensure their consistency.
-func verifyConsistency(provenanceIRs []common.ProvenanceIR) (verifier.VerificationResult, error) {
+func verifyConsistency(provenanceIRs []common.ProvenanceIR) verifier.VerificationResult {
 	result := verifier.NewVerificationResult()
 	// get the binary digest and binary name of the first provenance as reference
 	refBinaryDigest := provenanceIRs[0].GetBinarySHA256Digest()
@@ -149,16 +146,14 @@ func verifyConsistency(provenanceIRs []common.ProvenanceIR) (verifier.Verificati
 				provenanceIRs[ind].GetBinarySHA256Digest(), refBinaryDigest))
 		}
 
-		binaryName := provenanceIRs[ind].GetBinaryName()
-
-		if binaryName != refBinaryName {
+		if provenanceIRs[ind].GetBinaryName() != refBinaryName {
 			result.SetFailed(
 				fmt.Sprintf("provenances are not consistent: unexpected subject name in provenance #%d; got %q, want %q",
 					ind,
-					binaryName, refBinaryName))
+					provenanceIRs[ind].GetBinaryName(), refBinaryName))
 		}
 	}
-	return result, nil
+	return result
 }
 
 func getProvenanceBytes(provenanceURI string) ([]byte, error) {

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -136,7 +136,7 @@ type ProvenanceMetadataVerifier struct {
 // ProvenanceMetadataVerifier instance.
 // TODO(#69): Check metadata against the expected values.
 func (verifier *ProvenanceMetadataVerifier) Verify() (VerificationResult, error) {
-	provenanceIR, err := common.FromProvenance(verifier.Got)
+	provenanceIR, err := common.FromValidatedProvenance(verifier.Got)
 	if err != nil {
 		return VerificationResult{}, fmt.Errorf("could not parse provenance into ProvenanceIR: %v", err)
 	}

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -124,31 +124,6 @@ func chdir(dir string) {
 	}
 }
 
-// ProvenanceMetadataVerifier verifies provenances by comparing the
-// content of the provenance predicate against a given set of expected values.
-type ProvenanceMetadataVerifier struct {
-	Got  *types.ValidatedProvenance
-	Want *common.ReferenceValues
-	// TODO(#69): Add metadata fields.
-}
-
-// Verify verifies a given provenance file by checking its content against the expected values
-// ProvenanceMetadataVerifier instance.
-// TODO(#69): Check metadata against the expected values.
-func (verifier *ProvenanceMetadataVerifier) Verify() (VerificationResult, error) {
-	provenanceIR, err := common.FromValidatedProvenance(verifier.Got)
-	if err != nil {
-		return VerificationResult{}, fmt.Errorf("could not parse provenance into ProvenanceIR: %v", err)
-	}
-
-	provenanceVerifier := ProvenanceIRVerifier{
-		Got:  provenanceIR,
-		Want: verifier.Want,
-	}
-
-	return provenanceVerifier.Verify()
-}
-
 // ProvenanceIRVerifier verifies a provenance against a given reference, by verifying
 // all non-empty fields in got using fields in the reference values. Empty fields will not be verified.
 type ProvenanceIRVerifier struct {
@@ -199,11 +174,7 @@ func (verifier *ProvenanceIRVerifier) Verify() (VerificationResult, error) {
 func verifyBinarySHA256Digest(want *common.ReferenceValues, got *common.ProvenanceIR) (VerificationResult, error) {
 	result := NewVerificationResult()
 
-	gotBinarySHA256Digest, err := got.GetBinarySHA256Digest()
-
-	if err != nil {
-		return result, err
-	}
+	gotBinarySHA256Digest := got.GetBinarySHA256Digest()
 
 	if want.BinarySHA256Digests == nil {
 		return result, fmt.Errorf("no reference binary SHA256 digests given")

--- a/internal/verifier/verifier_test.go
+++ b/internal/verifier/verifier_test.go
@@ -32,6 +32,7 @@ const (
 	invalidHashProvenancePath = "invalid_hash_amber_provenance.json"
 	badCommandProvenancePath  = "bad_command_amber_provenance.json"
 	binarySHA256Digest        = "322527c0260e25f0e9a2595bd0d71a52294fe2397a7af76165190fd98de8920d"
+	binaryName                = "test.txt-9b5f98310dbbad675834474fa68c37d880687cb9"
 )
 
 func TestReproducibleProvenanceVerifier_validProvenance(t *testing.T) {
@@ -98,7 +99,7 @@ func TestReproducibleProvenanceVerifier_badCommand(t *testing.T) {
 
 func TestVerifyHasNoValues(t *testing.T) {
 	// There are no optional fields set apart from the binary digest and the build type.
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1)
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName)
 
 	want := common.ReferenceValues{
 		// We ask for all the optional values in the reference values.
@@ -122,7 +123,7 @@ func TestVerifyHasNoValues(t *testing.T) {
 }
 
 func TestVerifyHasBuildCmd_HasAndNeedsBuildCmd(t *testing.T) {
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuildCmd([]string{"build cmd"}))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuildCmd([]string{"build cmd"}))
 
 	want := common.ReferenceValues{
 		WantBuildCmds: true,
@@ -143,7 +144,7 @@ func TestVerifyHasBuildCmd_HasAndNeedsBuildCmd(t *testing.T) {
 
 func TestVerify_NeedsButCannotHaveNoBuildCmd(t *testing.T) {
 	// No buildCmd is set in the provenance.
-	got := common.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType)
+	got := common.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName)
 
 	want := common.ReferenceValues{
 		WantBuildCmds: true,
@@ -164,7 +165,7 @@ func TestVerify_NeedsButCannotHaveNoBuildCmd(t *testing.T) {
 
 func TestVerify_NeedsButHasNoBuildCmd(t *testing.T) {
 	// The build command is empty.
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuildCmd([]string{}))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuildCmd([]string{}))
 	// And the reference values ask for a build cmd.
 	want := common.ReferenceValues{
 		WantBuildCmds: true,
@@ -192,7 +193,7 @@ func TestVerify_NeedsButHasNoBuildCmd(t *testing.T) {
 
 func TestVerify_HasNoBuildCmdButNotNeeded(t *testing.T) {
 	// The build command is empty.
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuildCmd([]string{}))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuildCmd([]string{}))
 	// But the reference values do not ask for a build cmd.
 	want := common.ReferenceValues{
 		WantBuildCmds: false,
@@ -214,7 +215,7 @@ func TestVerify_HasNoBuildCmdButNotNeeded(t *testing.T) {
 
 func TestVerify_HasAndNeedsBuilderImageDigest(t *testing.T) {
 	builderDigest := "9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuilderImageSHA256Digest(builderDigest))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuilderImageSHA256Digest(builderDigest))
 	want := common.ReferenceValues{
 		BuilderImageSHA256Digests: []string{"some_other_digest", builderDigest},
 	}
@@ -233,7 +234,7 @@ func TestVerify_HasAndNeedsBuilderImageDigest(t *testing.T) {
 
 func TestVerify_NeedsButBuilderImageDigestNotFound(t *testing.T) {
 	builderDigest := "9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuilderImageSHA256Digest(builderDigest))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuilderImageSHA256Digest(builderDigest))
 	want := common.ReferenceValues{
 		BuilderImageSHA256Digests: []string{"some_other_digest", "and_some_other"},
 	}
@@ -260,7 +261,7 @@ func TestVerify_NeedsButBuilderImageDigestNotFound(t *testing.T) {
 }
 
 func TestVerify_NeedsButHasEmptyBuilderImageDigest(t *testing.T) {
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuilderImageSHA256Digest(""))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuilderImageSHA256Digest(""))
 	want := common.ReferenceValues{
 		BuilderImageSHA256Digests: []string{"some_digest"},
 	}
@@ -288,7 +289,7 @@ func TestVerify_NeedsButHasEmptyBuilderImageDigest(t *testing.T) {
 
 func TestVerify_HasEmptyBuilderImageDigestButNotNeeded(t *testing.T) {
 	builderImageSHA256Digest := ""
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, common.WithBuilderImageSHA256Digest(builderImageSHA256Digest))
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName, common.WithBuilderImageSHA256Digest(builderImageSHA256Digest))
 	want := common.ReferenceValues{
 		// We do not check for the builder image digest.
 	}
@@ -306,7 +307,7 @@ func TestVerify_HasEmptyBuilderImageDigestButNotNeeded(t *testing.T) {
 }
 
 func TestVerify_HasFoundRepoURI(t *testing.T) {
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1,
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName,
 		common.WithRepoURIs([]string{
 			"git+https://github.com/project-oak/transparent-release@refs/heads/main",
 			"https://github.com/project-oak/transparent-release",
@@ -334,7 +335,7 @@ func TestVerify_HasFoundRepoURI(t *testing.T) {
 func TestVerify_HasWrongRepoURI(t *testing.T) {
 	wrongURI := "git+https://github.com/project-oak/oak@refs/heads/main"
 	got := common.NewProvenanceIR(binarySHA256Digest,
-		amber.AmberBuildTypeV1,
+		amber.AmberBuildTypeV1, binaryName,
 		common.WithRepoURIs([]string{
 			wrongURI,
 			"https://github.com/project-oak/transparent-release",
@@ -367,7 +368,7 @@ func TestVerify_HasWrongRepoURI(t *testing.T) {
 
 func TestVerify_HasNoRepoURIs(t *testing.T) {
 	// We have no repo URIs in the provenance.
-	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1,
+	got := common.NewProvenanceIR(binarySHA256Digest, amber.AmberBuildTypeV1, binaryName,
 		common.WithRepoURIs([]string{}))
 	want := common.ReferenceValues{
 		RepoURI: "github.com/project-oak/transparent-release",


### PR DESCRIPTION
Fixes #165 .

- add binaryName, GetBinaryName, WithBinaryName to ProvenanceIR
- add comment on `ValidatedProvenance` why it is a necessary intermediate format, i.e., to determine the underlying provenance format, e.g., amber, slsav02, …
- rename `FromProvenance` to `FromValidatedProvenance` 
- remove superflous `ProvenanceMetadataVerifier`