### PR TITLE
Release the verifier instead of the builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
       - "main"
     tags:
       - "v*"
+  pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-    main: ./cmd/builder
+    main: ./cmd/verifier
 archives:
   - replacements:
       linux: Linux


### PR DESCRIPTION
Since the builder is removed now the `releaser` fails. This updates the release to release `cmd/verifier` instead of `cmd/builder`.

Also updates the `release` workflow to run as a CI step on pull requests.