### PR TITLE
Extract commit hash from provenance

### DIFF
--- a/internal/endorser/endorser_test.go
+++ b/internal/endorser/endorser_test.go
@@ -208,7 +208,7 @@ func TestLoadAndVerifyProvenances_NotVerified(t *testing.T) {
 		t.Fatalf("got %q, want error message containing %q,", err, want)
 	}
 
-	want = "does not contain the repo URI"
+	want = "is different from the repo URI"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("got %q, want error message containing %q,", err, want)
 	}

--- a/internal/model/provenance.go
+++ b/internal/model/provenance.go
@@ -207,7 +207,7 @@ func fromSLSAv02(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 		return nil, fmt.Errorf("could not parse provenance predicate: %v", err)
 	}
 
-	repoURI, commitHash := slsav02.GetGitURIAndDigest(*predicate)
+	repoURI, commitHash := slsav02.RepoURIAndDigest(*predicate)
 
 	// A ValidatedProvenance has a binary name.
 	binaryName := provenance.GetBinaryName()
@@ -237,7 +237,7 @@ func fromSLSAv1(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 		return nil, fmt.Errorf("parsing SLSA v1 provenance predicate: %v", err)
 	}
 
-	repoURI, commitDigest := slsav1.GitURIAndDigest(*predicate)
+	repoURI, commitDigest := slsav1.RepoURIAndDigest(*predicate)
 	builder := slsav1.BuilderID(*predicate)
 	buildCmd := slsav1.BuildCmd(*predicate)
 	builderImageDigest, err := slsav1.BuilderImageDigest(*predicate)

--- a/internal/model/provenance.go
+++ b/internal/model/provenance.go
@@ -207,7 +207,7 @@ func fromSLSAv02(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 		return nil, fmt.Errorf("could not parse provenance predicate: %v", err)
 	}
 
-	repoURI, commitHash := slsav02.RepoURIAndDigest(*predicate)
+	repoURI, commitHash := predicate.RepoURIAndDigest()
 
 	// A ValidatedProvenance has a binary name.
 	binaryName := provenance.GetBinaryName()
@@ -237,10 +237,10 @@ func fromSLSAv1(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 		return nil, fmt.Errorf("parsing SLSA v1 provenance predicate: %v", err)
 	}
 
-	repoURI, commitDigest := slsav1.RepoURIAndDigest(*predicate)
-	builder := slsav1.BuilderID(*predicate)
-	buildCmd := slsav1.BuildCmd(*predicate)
-	builderImageDigest, err := slsav1.BuilderImageDigest(*predicate)
+	repoURI, commitDigest := predicate.RepoURIAndDigest()
+	builder := predicate.BuilderID()
+	buildCmd := predicate.BuildCmd()
+	builderImageDigest, err := predicate.BuilderImageDigest()
 	if err != nil {
 		return nil, fmt.Errorf("getting builder image digest from SLSA v1 provenance: %v", err)
 	}

--- a/internal/model/provenance.go
+++ b/internal/model/provenance.go
@@ -42,7 +42,8 @@ type ProvenanceIR struct {
 	binaryName               string
 	buildCmd                 *[]string
 	builderImageSHA256Digest *string
-	repoURIs                 *[]string
+	repoURI                  *string
+	commitSHA1Digest         *string
 	trustedBuilder           *string
 }
 
@@ -79,9 +80,14 @@ func (p *ProvenanceIR) BuildCmd() ([]string, error) {
 	return *p.buildCmd, nil
 }
 
-// RepoURIs returns repo URIs in the provenance.
-func (p *ProvenanceIR) RepoURIs() []string {
-	return *p.repoURIs
+// RepoURI returns repo URI in the provenance.
+func (p *ProvenanceIR) RepoURI() string {
+	return *p.repoURI
+}
+
+// CommitSHA1Digest returns the SHA1 commit digest in the provenance.
+func (p *ProvenanceIR) CommitSHA1Digest() string {
+	return *p.commitSHA1Digest
 }
 
 // BuilderImageSHA256Digest returns the builder image sha256 digest, or an
@@ -126,16 +132,28 @@ func (p *ProvenanceIR) HasBuilderImageSHA256Digest() bool {
 	return p.builderImageSHA256Digest != nil
 }
 
-// WithRepoURIs sets repo URIs referenced in the provenance when creating a new ProvenanceIR.
-func WithRepoURIs(repoURIs []string) func(p *ProvenanceIR) {
+// WithRepoURI sets repo URI referenced in the provenance when creating a new ProvenanceIR.
+func WithRepoURI(repoURI string) func(p *ProvenanceIR) {
 	return func(p *ProvenanceIR) {
-		p.repoURIs = &repoURIs
+		p.repoURI = &repoURI
 	}
 }
 
-// HasRepoURIs returns true if repo URIs have been set in the ProvenanceIR.
-func (p *ProvenanceIR) HasRepoURIs() bool {
-	return p.repoURIs != nil
+// WithCommitSHA1Digest sets the commit digest in the provenance when creating a new ProvenanceIR.
+func WithCommitSHA1Digest(commitSHA1Digest string) func(p *ProvenanceIR) {
+	return func(p *ProvenanceIR) {
+		p.commitSHA1Digest = &commitSHA1Digest
+	}
+}
+
+// HasRepoURI returns true if repo URI has been set in the ProvenanceIR.
+func (p *ProvenanceIR) HasRepoURI() bool {
+	return p.repoURI != nil
+}
+
+// HasCommitSHA1Digest returns true if the commit digest has been set in the ProvenanceIR.
+func (p *ProvenanceIR) HasCommitSHA1Digest() bool {
+	return p.commitSHA1Digest != nil
 }
 
 // WithTrustedBuilder sets the trusted builder when creating a new ProvenanceIR.
@@ -189,9 +207,7 @@ func fromSLSAv02(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 		return nil, fmt.Errorf("could not parse provenance predicate: %v", err)
 	}
 
-	// We collect repo uris from where they appear in the provenance to verify
-	// that they point to the same reference repo uri.
-	repoURIs := slsav02.GetMaterialsGitURI(*predicate)
+	repoURI, commitHash := slsav02.GetGitURIAndDigest(*predicate)
 
 	// A ValidatedProvenance has a binary name.
 	binaryName := provenance.GetBinaryName()
@@ -199,7 +215,8 @@ func fromSLSAv02(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 	builder := predicate.Builder.ID
 
 	provenanceIR := NewProvenanceIR(binarySHA256Digest, buildType, binaryName,
-		WithRepoURIs(repoURIs),
+		WithRepoURI(*repoURI),
+		WithCommitSHA1Digest(*commitHash),
 		WithTrustedBuilder(builder),
 	)
 	return provenanceIR, nil
@@ -220,7 +237,7 @@ func fromSLSAv1(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 		return nil, fmt.Errorf("parsing SLSA v1 provenance predicate: %v", err)
 	}
 
-	repoURIs := slsav1.GitURI(*predicate)
+	repoURI, commitDigest := slsav1.GitURIAndDigest(*predicate)
 	builder := slsav1.BuilderID(*predicate)
 	buildCmd := slsav1.BuildCmd(*predicate)
 	builderImageDigest, err := slsav1.BuilderImageDigest(*predicate)
@@ -229,7 +246,8 @@ func fromSLSAv1(provenance *ValidatedProvenance) (*ProvenanceIR, error) {
 	}
 
 	provenanceIR := NewProvenanceIR(binarySHA256Digest, buildType, binaryName,
-		WithRepoURIs(repoURIs),
+		WithRepoURI(*repoURI),
+		WithCommitSHA1Digest(*commitDigest),
 		WithTrustedBuilder(builder),
 		WithBuildCmd(buildCmd),
 		WithBuilderImageSHA256Digest(builderImageDigest),

--- a/internal/model/provenance_test.go
+++ b/internal/model/provenance_test.go
@@ -55,7 +55,8 @@ func TestFromProvenance_Slsav02(t *testing.T) {
 
 	want := NewProvenanceIR("d059c38cea82047ad316a1c6c6fbd13ecf7a0abdcc375463920bd25bf5c142cc",
 		slsav02.GenericSLSABuildType, "oak_functions_freestanding_bin",
-		WithRepoURIs([]string{"git+https://github.com/project-oak/oak@refs/heads/main"}),
+		WithRepoURI("git+https://github.com/project-oak/oak@refs/heads/main"),
+		WithCommitSHA1Digest("1b128fb2556e4bdcc4f92552654bfbca9d2fb8c6"),
 		WithTrustedBuilder("https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.2.0"),
 	)
 
@@ -90,7 +91,8 @@ func TestFromProvenance_Slsav1(t *testing.T) {
 			"--release",
 		}),
 		WithBuilderImageSHA256Digest("51532c757d1008bbff696d053a1d05226f6387cf232aa80b6f9c13b0759ccea0"),
-		WithRepoURIs([]string{"git+https://github.com/project-oak/oak"}),
+		WithRepoURI("git+https://github.com/project-oak/oak"),
+		WithCommitSHA1Digest("6bac02b6b0442ed944f57b7cba9a5f1119863ca4"),
 		WithTrustedBuilder("https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_docker-based_slsa3.yml@refs/tags/v1.6.0-rc.0"),
 	)
 

--- a/internal/verification/verifier.go
+++ b/internal/verification/verifier.go
@@ -17,7 +17,6 @@ package verification
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/project-oak/transparent-release/internal/model"
 	"go.uber.org/multierr"
@@ -48,7 +47,7 @@ func (v *ProvenanceIRVerifier) Verify() error {
 	}
 
 	// Verify RepoURIs.
-	multierr.AppendInto(&errs, v.verifyRepoURIs())
+	multierr.AppendInto(&errs, v.verifyRepoURI())
 
 	// Verify TrustedBuilder.
 	if err := v.verifyTrustedBuilder(); err != nil {
@@ -111,21 +110,19 @@ func (v *ProvenanceIRVerifier) verifyBuilderImageDigest() error {
 		gotBuilderImageDigest)
 }
 
-// verifyRepoURIs verifies that the references to URIs in the Got provenance
-// match the repo URI in the Want reference values.
-func (v *ProvenanceIRVerifier) verifyRepoURIs() error {
+// verifyRepoURI verifies that the Git URI in the Got provenance
+// is the same as the repo URI in the Want reference values.
+func (v *ProvenanceIRVerifier) verifyRepoURI() error {
 	var errs error
 
-	if !v.Got.HasRepoURIs() || v.Want.RepoURI == "" {
+	if !v.Got.HasRepoURI() || v.Want.RepoURI == "" {
 		return nil
 	}
 
-	for _, gotRepoURI := range v.Got.RepoURIs() {
-		// We want the want.RepoURI be contained in every repo uri from the provenance.
-		if !strings.Contains(gotRepoURI, v.Want.RepoURI) {
-			multierr.AppendInto(&errs, fmt.Errorf("the URI from the provenance (%v) does not contain the repo URI (%v)", gotRepoURI, v.Want.RepoURI))
-		}
+	if v.Got.RepoURI() != v.Want.RepoURI {
+		multierr.AppendInto(&errs, fmt.Errorf("the URI from the provenance (%v) is different from the repo URI (%v)", v.Got.RepoURI(), v.Want.RepoURI))
 	}
+
 	return errs
 }
 

--- a/internal/verification/verifier_test.go
+++ b/internal/verification/verifier_test.go
@@ -52,7 +52,7 @@ func TestVerify_HasNoValues(t *testing.T) {
 	}
 }
 
-func TestVerify_HasBuildCmd_HasAndNeedsBuildCmd(t *testing.T) {
+func TestVerify_NeedsCanHaveHasBuildCmd(t *testing.T) {
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuildCmd([]string{"build cmd"}))
 
 	want := ReferenceValues{
@@ -69,7 +69,7 @@ func TestVerify_HasBuildCmd_HasAndNeedsBuildCmd(t *testing.T) {
 	}
 }
 
-func TestVerify_NeedsButCannotHaveNoBuildCmd(t *testing.T) {
+func TestVerify_NeedsCannotHaveDoesNotHaveBuildCmd(t *testing.T) {
 	// No buildCmd is set in the provenance.
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName)
 
@@ -87,7 +87,7 @@ func TestVerify_NeedsButCannotHaveNoBuildCmd(t *testing.T) {
 	}
 }
 
-func TestVerify_NeedsButHasNoBuildCmd(t *testing.T) {
+func TestVerify__NeedsCannotHaveHasEmptyBuildCmd(t *testing.T) {
 	// The build command is empty.
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuildCmd([]string{}))
 	// And the reference values ask for a build cmd.
@@ -106,7 +106,7 @@ func TestVerify_NeedsButHasNoBuildCmd(t *testing.T) {
 	}
 }
 
-func TestVerify_HasNoBuildCmdButNotNeeded(t *testing.T) {
+func TestVerify_DoesNotNeedCannotHaveHasEmptyBuildCmd(t *testing.T) {
 	// The build command is empty.
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuildCmd([]string{}))
 	// But the reference values do not ask for a build cmd.
@@ -125,7 +125,7 @@ func TestVerify_HasNoBuildCmdButNotNeeded(t *testing.T) {
 	}
 }
 
-func TestVerify_HasAndNeedsBuilderImageDigest(t *testing.T) {
+func TestVerify_NeedsHasBuilderImageDigest(t *testing.T) {
 	builderDigest := "9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuilderImageSHA256Digest(builderDigest))
 	want := ReferenceValues{
@@ -142,7 +142,7 @@ func TestVerify_HasAndNeedsBuilderImageDigest(t *testing.T) {
 	}
 }
 
-func TestVerify_NeedsButBuilderImageDigestNotFound(t *testing.T) {
+func TestVerify_NeedsDoesNotHaveBuilderImageDigest(t *testing.T) {
 	builderDigest := "9e2ba52487d945504d250de186cb4fe2e3ba023ed2921dd6ac8b97ed43e76af9"
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuilderImageSHA256Digest(builderDigest))
 	want := ReferenceValues{
@@ -162,7 +162,7 @@ func TestVerify_NeedsButBuilderImageDigestNotFound(t *testing.T) {
 	}
 }
 
-func TestVerify_NeedsButHasEmptyBuilderImageDigest(t *testing.T) {
+func TestVerify_NeedsHasEmptyBuilderImageDigest(t *testing.T) {
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuilderImageSHA256Digest(""))
 	want := ReferenceValues{
 		BuilderImageSHA256Digests: []string{"some_digest"},
@@ -181,7 +181,7 @@ func TestVerify_NeedsButHasEmptyBuilderImageDigest(t *testing.T) {
 	}
 }
 
-func TestVerify_HasEmptyBuilderImageDigestButNotNeeded(t *testing.T) {
+func TestVerify_DoesNotNeedHasEmptyBuilderImageDigest(t *testing.T) {
 	builderImageSHA256Digest := ""
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithBuilderImageSHA256Digest(builderImageSHA256Digest))
 	want := ReferenceValues{
@@ -198,7 +198,7 @@ func TestVerify_HasEmptyBuilderImageDigestButNotNeeded(t *testing.T) {
 	}
 }
 
-func TestVerify_HasFoundRepoURI(t *testing.T) {
+func TestVerify_HasWantedRepoURI(t *testing.T) {
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName,
 		model.WithRepoURI("https://github.com/project-oak/transparent-release"))
 	want := ReferenceValues{
@@ -257,7 +257,7 @@ func TestVerify_HasNoRepoURIs(t *testing.T) {
 	}
 }
 
-func TestVerify_HasAndNeedsTrustedBuilder(t *testing.T) {
+func TestVerify_NeedsHasTrustedBuilder(t *testing.T) {
 	trustedBuilder := "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.2.0"
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithTrustedBuilder(trustedBuilder))
 
@@ -275,7 +275,7 @@ func TestVerify_HasAndNeedsTrustedBuilder(t *testing.T) {
 	}
 }
 
-func TestVerify_NeedsButTrustedBuilderNotFound(t *testing.T) {
+func TestVerify_NeedsDoesNotHaveTrustedBuilder(t *testing.T) {
 	trustedBuilder := "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v1.2.0"
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithTrustedBuilder(trustedBuilder))
 
@@ -296,7 +296,7 @@ func TestVerify_NeedsButTrustedBuilderNotFound(t *testing.T) {
 	}
 }
 
-func TestVerify_NeedsButHasEmptyTrustedBuilder(t *testing.T) {
+func TestVerify_NeedsHasEmptyTrustedBuilder(t *testing.T) {
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithTrustedBuilder(""))
 
 	want := ReferenceValues{
@@ -316,7 +316,7 @@ func TestVerify_NeedsButHasEmptyTrustedBuilder(t *testing.T) {
 	}
 }
 
-func TestVerify_HasEmptyTrustedBuilderButNotNeeded(t *testing.T) {
+func TestVerify_DoesNotNeedHasEmptyTrustedBuilder(t *testing.T) {
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName, model.WithTrustedBuilder(""))
 
 	want := ReferenceValues{

--- a/internal/verification/verifier_test.go
+++ b/internal/verification/verifier_test.go
@@ -200,12 +200,9 @@ func TestVerify_HasEmptyBuilderImageDigestButNotNeeded(t *testing.T) {
 
 func TestVerify_HasFoundRepoURI(t *testing.T) {
 	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName,
-		model.WithRepoURIs([]string{
-			"git+https://github.com/project-oak/transparent-release@refs/heads/main",
-			"https://github.com/project-oak/transparent-release",
-		}))
+		model.WithRepoURI("https://github.com/project-oak/transparent-release"))
 	want := ReferenceValues{
-		RepoURI: "github.com/project-oak/transparent-release",
+		RepoURI: "https://github.com/project-oak/transparent-release",
 	}
 
 	verifier := ProvenanceIRVerifier{
@@ -223,10 +220,7 @@ func TestVerify_HasWrongRepoURI(t *testing.T) {
 	wrongURI := "git+https://github.com/project-oak/oak@refs/heads/main"
 	got := model.NewProvenanceIR(binarySHA256Digest,
 		slsav02.GenericSLSABuildType, binaryName,
-		model.WithRepoURIs([]string{
-			wrongURI,
-			"https://github.com/project-oak/transparent-release",
-		}))
+		model.WithRepoURI(wrongURI))
 	want := ReferenceValues{
 		RepoURI: "github.com/project-oak/transparent-release",
 	}
@@ -236,7 +230,7 @@ func TestVerify_HasWrongRepoURI(t *testing.T) {
 		Want: &want,
 	}
 
-	wantErr := fmt.Sprintf("the URI from the provenance (%v) does not contain the repo URI (%v)",
+	wantErr := fmt.Sprintf("the URI from the provenance (%v) is different from the repo URI (%v)",
 		wrongURI,
 		want.RepoURI,
 	)
@@ -247,8 +241,7 @@ func TestVerify_HasWrongRepoURI(t *testing.T) {
 
 func TestVerify_HasNoRepoURIs(t *testing.T) {
 	// We have no repo URIs in the provenance.
-	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName,
-		model.WithRepoURIs([]string{}))
+	got := model.NewProvenanceIR(binarySHA256Digest, slsav02.GenericSLSABuildType, binaryName)
 	want := ReferenceValues{
 		RepoURI: "github.com/project-oak/transparent-release",
 	}

--- a/pkg/intoto/slsa_provenance/v0.2/provenance.go
+++ b/pkg/intoto/slsa_provenance/v0.2/provenance.go
@@ -187,9 +187,9 @@ func ParseSLSAv02Predicate(predicate interface{}) (*ProvenancePredicate, error) 
 	return &pp, nil
 }
 
-// GetGitURIAndDigest returns the URI of the Git repo and the commit hast
+// RepoURIAndDigest returns the URI of the Git repo and the commit hash
 // extracted from materials.
-func GetGitURIAndDigest(pred ProvenancePredicate) (*string, *string) {
+func RepoURIAndDigest(pred ProvenancePredicate) (*string, *string) {
 	materials := pred.Materials
 	for _, material := range materials {
 		if strings.Contains(material.URI, "git") {

--- a/pkg/intoto/slsa_provenance/v0.2/provenance.go
+++ b/pkg/intoto/slsa_provenance/v0.2/provenance.go
@@ -189,8 +189,8 @@ func ParseSLSAv02Predicate(predicate interface{}) (*ProvenancePredicate, error) 
 
 // RepoURIAndDigest returns the URI of the Git repo and the commit hash
 // extracted from materials.
-func RepoURIAndDigest(pred ProvenancePredicate) (*string, *string) {
-	materials := pred.Materials
+func (p *ProvenancePredicate) RepoURIAndDigest() (*string, *string) {
+	materials := p.Materials
 	for _, material := range materials {
 		if strings.Contains(material.URI, "git") {
 			digest := material.Digest["sha1"]

--- a/pkg/intoto/slsa_provenance/v0.2/provenance.go
+++ b/pkg/intoto/slsa_provenance/v0.2/provenance.go
@@ -187,16 +187,15 @@ func ParseSLSAv02Predicate(predicate interface{}) (*ProvenancePredicate, error) 
 	return &pp, nil
 }
 
-// GetMaterialsGitURI returns references to a Git repo.
-func GetMaterialsGitURI(pred ProvenancePredicate) []string {
+// GetGitURIAndDigest returns the URI of the Git repo and the commit hast
+// extracted from materials.
+func GetGitURIAndDigest(pred ProvenancePredicate) (*string, *string) {
 	materials := pred.Materials
-	gitURIs := []string{}
 	for _, material := range materials {
-		// This may be an overestimation and get too many repositiories.
-		// However, even if we get a "wrong" repository, worst case verifying the provenance fails, when it should not.
 		if strings.Contains(material.URI, "git") {
-			gitURIs = append(gitURIs, material.URI)
+			digest := material.Digest["sha1"]
+			return &material.URI, &digest
 		}
 	}
-	return gitURIs
+	return nil, nil
 }

--- a/pkg/intoto/slsa_provenance/v1/provenance.go
+++ b/pkg/intoto/slsa_provenance/v1/provenance.go
@@ -212,8 +212,8 @@ func BuilderImageDigest(predicate ProvenancePredicate) (string, error) {
 	return digest, nil
 }
 
-// GitURIAndDigest returns the URI of the Git repo and the SHA1 commit hash.
-func GitURIAndDigest(predicate ProvenancePredicate) (*string, *string) {
+// RepoURIAndDigest returns the URI of the Git repo and the SHA1 commit hash.
+func RepoURIAndDigest(predicate ProvenancePredicate) (*string, *string) {
 	src := predicate.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).Source
 	if strings.Contains(src.URI, "git") {
 		digest := src.Digest["sha1"]

--- a/pkg/intoto/slsa_provenance/v1/provenance.go
+++ b/pkg/intoto/slsa_provenance/v1/provenance.go
@@ -212,14 +212,14 @@ func BuilderImageDigest(predicate ProvenancePredicate) (string, error) {
 	return digest, nil
 }
 
-// GitURI returns references to a Git repo.
-func GitURI(predicate ProvenancePredicate) []string {
+// GitURIAndDigest returns the URI of the Git repo and the SHA1 commit hash.
+func GitURIAndDigest(predicate ProvenancePredicate) (*string, *string) {
 	src := predicate.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).Source
-	gitURIs := []string{}
 	if strings.Contains(src.URI, "git") {
-		gitURIs = append(gitURIs, src.URI)
+		digest := src.Digest["sha1"]
+		return &src.URI, &digest
 	}
-	return gitURIs
+	return nil, nil
 }
 
 // BuilderID extracts and returns the builder ID from the given ProvenancePredicate.

--- a/pkg/intoto/slsa_provenance/v1/provenance.go
+++ b/pkg/intoto/slsa_provenance/v1/provenance.go
@@ -197,13 +197,13 @@ func ParseContainerBasedSLSAv1Provenance(predicate interface{}) (*ProvenancePred
 }
 
 // BuildCmd extracts and returns the build command from the given ProvenancePredicate.
-func BuildCmd(predicate ProvenancePredicate) []string {
-	return predicate.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).Config.Command
+func (p *ProvenancePredicate) BuildCmd() []string {
+	return p.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).Config.Command
 }
 
 // BuilderImageDigest extracts and returns the digest for the Builder Image.
-func BuilderImageDigest(predicate ProvenancePredicate) (string, error) {
-	digestSet := predicate.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).BuilderImage.Digest
+func (p *ProvenancePredicate) BuilderImageDigest() (string, error) {
+	digestSet := p.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).BuilderImage.Digest
 	digest, ok := digestSet["sha256"]
 	if !ok {
 		return "", fmt.Errorf("no SHA256 builder image digest in the digest set: %v", digestSet)
@@ -213,8 +213,8 @@ func BuilderImageDigest(predicate ProvenancePredicate) (string, error) {
 }
 
 // RepoURIAndDigest returns the URI of the Git repo and the SHA1 commit hash.
-func RepoURIAndDigest(predicate ProvenancePredicate) (*string, *string) {
-	src := predicate.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).Source
+func (p *ProvenancePredicate) RepoURIAndDigest() (*string, *string) {
+	src := p.BuildDefinition.ExternalParameters.(DockerBasedExternalParameters).Source
 	if strings.Contains(src.URI, "git") {
 		digest := src.Digest["sha1"]
 		return &src.URI, &digest
@@ -223,6 +223,6 @@ func RepoURIAndDigest(predicate ProvenancePredicate) (*string, *string) {
 }
 
 // BuilderID extracts and returns the builder ID from the given ProvenancePredicate.
-func BuilderID(predicate ProvenancePredicate) string {
-	return predicate.RunDetails.Builder.ID
+func (p *ProvenancePredicate) BuilderID() string {
+	return p.RunDetails.Builder.ID
 }


### PR DESCRIPTION
While we don't verify the commit hash against a reference value, since ProvenanceIR is the internal representation, it should contain the commit hash.

This PR adds a new `commitSHA1Hash` field to `ProvenanceIR`. It also simplifies `RepoURIs` to be a single value. In all provenance formats, there is only one possible value for the source repo.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass